### PR TITLE
Reorder reservation validations to reduce bugs

### DIFF
--- a/app/models/sulten/reservation.rb
+++ b/app/models/sulten/reservation.rb
@@ -5,14 +5,40 @@ class Sulten::Reservation < ActiveRecord::Base
   attr_accessible :reservation_from, :reservation_duration, :reservation_to, :people, :name,
     :telephone, :email, :allergies, :internal_comment, :table_id, :reservation_type_id, :reservation_duration
 
-  validates_presence_of :reservation_from, :reservation_duration, :people, :name, :telephone, :email, :table_id, :reservation_type
+  attr_accessor :reservation_duration
 
-  validate :check_opening_hours, :reservation_is_one_day_in_future, :no_table_available, :check_reservation_duration, :check_amount_of_people, on: :create
+  validates_presence_of :reservation_from, :reservation_to, :reservation_duration, :people,
+    :name, :telephone, :email, :reservation_type
+
+  validate :check_opening_hours, :reservation_is_one_day_in_future, :check_amount_of_people, on: :create
 
   validate :email, email: true
 
-  def no_table_available
-    errors.add(:reservation_from, I18n.t("helpers.models.sulten.reservation.errors.reservation_from.no_table_available")) if self[:table_id].nil?
+  before_validation(on: :create) do
+    should_break = false
+
+    if not [30, 60, 90, 120].include? reservation_duration.to_i
+      errors.add(:reservation_duration, I18n.t("helpers.models.sulten.reservation.errors.people.check_reservation_duration"))
+      should_break = true
+    end
+
+    if reservation_from.nil?
+      errors.add(:reservation_from, 'Invalid date format')
+      should_break = true
+    end
+
+    return false if should_break
+
+    self.reservation_to = reservation_from + reservation_duration.to_i.minutes
+  end
+
+  after_validation(on: :create) do
+    self.table = Sulten::Reservation.find_table(reservation_from, reservation_to, people, reservation_type_id)
+
+    unless self.table
+      errors.add(:reservation_from,
+                 I18n.t("helpers.models.sulten.reservation.errors.reservation_from.no_table_available"))
+    end
   end
 
   def reservation_is_one_day_in_future
@@ -35,33 +61,15 @@ class Sulten::Reservation < ActiveRecord::Base
     end
   end
 
-  def check_reservation_duration
-    if not [30, 60, 90, 120].include? reservation_duration
-      errors.add(:reservation_duration, I18n.t("helpers.models.sulten.reservation.errors.people.check_reservation_duration"))
-    end
-  end
-
-  before_validation(on: :create) do
-    self.table = Sulten::Reservation.find_table(reservation_from, reservation_duration, people, reservation_type_id)
-  end
-
   def first_name
     self.name.partition(" ").first
   end
 
-  def reservation_duration=(value)
-    self.reservation_to = self.reservation_from + value.to_i.minutes
-  end
-
-  def reservation_duration
-    ((self.reservation_to - self.reservation_from) / 60).to_i if !(self.reservation_to.nil? && self.reservation_from.nil?) 
-  end
-
-  def self.find_table from, duration, people, reservation_type_id
+  def self.find_table from, to, people, reservation_type_id
     for i in 1..Sulten::ReservationType.all.length
       Sulten::Table.where("capacity >= ? and available = ?", people, true).order("capacity ASC").tables_with_i_reservation_types(i).find do |t|
         if t.reservation_types.pluck(:id).include? reservation_type_id
-          if t.reservations.where("reservation_from > ? or reservation_to < ?", from+duration.to_i.minutes, from).count == t.reservations.count
+          if t.reservations.where("reservation_from > ? or reservation_to < ?", to, from).count == t.reservations.count
             return t
           end
         end


### PR DESCRIPTION
reservation_duration is now guaranteed to be set before validation,
removing errors during validation phase.

Some other validations are also cleaned up in the process.
