### PR TITLE
Use html5 validations for email in buy form, fix other bugs

### DIFF
--- a/app/views/events/buy.html.haml
+++ b/app/views/events/buy.html.haml
@@ -61,12 +61,11 @@
     %p.payment-choice
       = radio_button_tag "ticket_type", "paper", @payment_error.try(:owner_email).present?
       = label_tag "ticket_type_paper", t('events.paperticket'), class: 'radio-label'
-      = text_field_tag :email, @payment_error.try(:owner_email), tabindex: 2
+      = email_field_tag :email, @payment_error.try(:owner_email), tabindex: 2
       = label_tag "email_confirmation", t('events.confirm_email')
-      = text_field_tag :email_confirmation, @payment_error.try(:owner_email), tabindex: 3
+      = email_field_tag :email_confirmation, @payment_error.try(:owner_email), tabindex: 3
       %span#email_feedback
         &nbsp;
-
 
     %h4
       = t('events.about_ticket')


### PR DESCRIPTION
This clears up some of the logic, as well as switching to html5 email validations (which are more relaxed in their restrictions).
