### PR TITLE
Add combined search for event and pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,7 @@ gem 'pg'
 
 # Provides PostgreSQL fulltext search. Contains wrappers for tsvectors
 # and enables searching in nested attributes.
-gem 'pg_search'
+gem 'pg_search', git: 'https://github.com/Casecommons/pg_search.git', ref: 'ff1af34'
 
 # Diff library used in history for information pages
 gem 'diff-lcs'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,14 @@
 GIT
+  remote: https://github.com/Casecommons/pg_search.git
+  revision: ff1af346322ca54808b3f53081149b8cac55bb76
+  ref: ff1af34
+  specs:
+    pg_search (1.0.5)
+      activerecord (>= 3.1)
+      activesupport (>= 3.1)
+      arel
+
+GIT
   remote: https://github.com/Samfundet/SamfundetAuth.git
   revision: 3c9a3851694a22389b554d4182a947587b9c1ad4
   specs:
@@ -210,10 +220,6 @@ GEM
     parser (2.3.0.6)
       ast (~> 2.2)
     pg (0.18.4)
-    pg_search (1.0.5)
-      activerecord (>= 3.1)
-      activesupport (>= 3.1)
-      arel
     polyglot (0.3.5)
     powerpack (0.1.1)
     pry (0.10.3)
@@ -318,7 +324,7 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.46)
+    tzinfo (0.3.48)
     uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
@@ -367,7 +373,7 @@ DEPENDENCIES
   paperclip (~> 4.2.2)
   paperclip-compression (= 0.3.5)
   pg
-  pg_search
+  pg_search!
   rack-livereload
   railroady
   rails (= 3.2.22.2)

--- a/app/assets/javascripts/site/header.js
+++ b/app/assets/javascripts/site/header.js
@@ -10,4 +10,10 @@ $(function() {
     $(".dropdown-button.menu-items .caret-wrapper").toggleClass('flip');
     event.preventDefault();
   });
+
+  $(".titlebar-search-link").click(function(e){
+    e.preventDefault();
+    $(".top-bar-search").toggle();
+    $(".top-bar-search #search_query").focus();
+  })
 });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -46,4 +46,5 @@
 @import "areas/areas";
 @import "billig/billig";
 @import "everything_closed_periods/everything_closed_periods";
-@import "images_show"
+@import "images_show";
+@import "search/search";

--- a/app/assets/stylesheets/search/search.css.scss
+++ b/app/assets/stylesheets/search/search.css.scss
@@ -1,0 +1,29 @@
+.search {
+	form {
+		input[type='text'] {
+			margin: 0, 10px;
+			padding: 10px;
+			font-size: 1em;
+			width: 250px;
+			border: 1px solid rgba(0,0,0,0.5);
+		}
+	}
+	hr{
+		border: 0;
+		border-bottom: 1px dashed #ccc;
+		background: #999;
+		margin: 1em 0;
+	}
+	.results {
+		.title {
+			a {
+				font-size: 25px;
+				font-weight: 300;
+			}
+			.time_place {
+				width: 100%;
+				color: $samfundet-medium-grey;
+			}
+		}
+	}
+}

--- a/app/assets/stylesheets/search/search.css.scss
+++ b/app/assets/stylesheets/search/search.css.scss
@@ -1,5 +1,8 @@
 .search {
 	form {
+    background-color: transparent !important;
+    margin-bottom: 5px !important;
+
 		input[type='text'] {
 			margin: 0, 10px;
 			padding: 10px;

--- a/app/assets/stylesheets/sitewide/_titlebar.css.scss
+++ b/app/assets/stylesheets/sitewide/_titlebar.css.scss
@@ -29,7 +29,7 @@ $image-aspect-ratio: 12;
         font-weight: bold;
         font-size: 0.7em;
 
-        .login, .control-panel, .my-applications, .titlebar-change-language-link {
+        .login, .control-panel, .my-applications, .titlebar-change-language-link, .titlebar-search-link {
             text-decoration: none;
             margin: 0 5px;
             color: white;
@@ -44,5 +44,40 @@ $image-aspect-ratio: 12;
         }
 
     }
+}
+.top-bar-search {
+  display: none;
+  max-width: 68em;
+  position: relative;
+  margin: 0 auto;
+  .tts {
 
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 2;
+
+    @include media($mobile) {
+      width: 100%;
+    }
+  }
+  form {
+    padding: 0 !important;
+    margin: 0 !important;
+    background-color: $samfundet-red !important;
+
+    input[type='submit'] {
+      border-left: 1px solid black;
+      padding: 5px 10px;
+      font-size: 0.7em;
+      font-weight: 400;
+    }
+    input[type='text'] {
+      max-width: 90%;
+      font-size: 0.7em;
+      padding: 2px 10px;
+      margin: 3px;
+    }
+
+  }
 }

--- a/app/assets/stylesheets/sitewide/_titlebar.css.scss
+++ b/app/assets/stylesheets/sitewide/_titlebar.css.scss
@@ -45,13 +45,14 @@ $image-aspect-ratio: 12;
 
     }
 }
+
 .top-bar-search {
   display: none;
   max-width: 68em;
   position: relative;
   margin: 0 auto;
-  .tts {
 
+  .tts {
     position: absolute;
     top: 0;
     right: 0;
@@ -61,6 +62,7 @@ $image-aspect-ratio: 12;
       width: 100%;
     }
   }
+
   form {
     padding: 0 !important;
     margin: 0 !important;
@@ -72,12 +74,12 @@ $image-aspect-ratio: 12;
       font-size: 0.7em;
       font-weight: 400;
     }
+
     input[type='text'] {
       max-width: 90%;
       font-size: 0.7em;
       padding: 2px 10px;
       margin: 3px;
     }
-
   }
 }

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,15 +1,4 @@
 class SearchController < ApplicationController
-  def new
-    @search = Search.new
-  end
-
-  def create
-    search = Search.new(params[:search])
-
-    @results = search.results
-
-    render :results
-  end
 
   def search
     @search = if params[:search]

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,0 +1,22 @@
+class SearchController < ApplicationController
+  def new
+    @search = Search.new
+  end
+
+  def create
+    search = Search.new(params[:search])
+
+    @results = search.results
+
+    render :results
+  end
+
+  def search
+    @search = if params[:search]
+                Search.new(params[:search])
+              else
+                Search.new
+              end
+    @results = @search.results.paginate(page: params[:page], per_page: 10) if @search.query?
+  end
+end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,5 +1,4 @@
 class SearchController < ApplicationController
-
   def search
     @search = if params[:search]
                 Search.new(params[:search])

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -102,6 +102,14 @@ class Event < ActiveRecord::Base
                     }
                   },
                   associated_against: { area: :name }
+  multisearchable against:
+                    [:non_billig_title_no,
+                     :title_en,
+                     :long_description_en,
+                     :long_description_no,
+                     :age_limit,
+                     :non_billig_start_time],
+                  additional_attributes: -> (record) { { publish_at: record.publication_time } }
 
   # Uses the above defined PgSearch scope to perform search.
   def self.text_search query

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -56,6 +56,14 @@ class Page < ActiveRecord::Base
     end
   end
 
+  include PgSearch
+  multisearchable against: [:title_no,
+                            :title_en,
+                            :content_no,
+                            :content_en],
+                  additional_attributes: -> (record) { { publish_at: record.created_at } },
+                  if: -> (record) { !%w(_menu _index).include? record.name_no }
+
   def self.find_by_name(name)
     if I18n.locale == :no
       find_by_name_no(name.downcase)

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -62,7 +62,7 @@ class Page < ActiveRecord::Base
                             :content_no,
                             :content_en],
                   additional_attributes: -> (record) { { publish_at: record.created_at } },
-                  if: -> (record) { !%w(_menu _index).include? record.name_no }
+                  if: -> (record) { %w(_menu _index).exclude? record.name_no }
 
   def self.find_by_name(name)
     if I18n.locale == :no

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -1,0 +1,26 @@
+class Search
+  extend ActiveModel::Naming
+  include ActiveModel::Conversion
+  include ActiveModel::Validations
+
+  attr_accessor :query
+
+  validates :query, presence: true
+
+  def persisted?
+    false
+  end
+
+  def initialize(params = {})
+    @query = params[:query]
+  end
+
+  def results
+    # RAILS4: Return PgSearch::Document.none when no query
+    PgSearch.multisearch(query).where("? >= publish_at", Time.current) if query
+  end
+
+  def query?
+    !query.nil?
+  end
+end

--- a/app/views/layouts/_titlebar.html.haml
+++ b/app/views/layouts/_titlebar.html.haml
@@ -2,6 +2,7 @@
   .container
     = link_to '', root_path, id: 'banner-logo'
     #session-status
+      = link_to t('search.submit'), search_path, class: 'titlebar-search-link'
       = link_to t('layouts.application.menu.change_language'), change_language, class: 'titlebar-change-language-link'
       - if logged_in?
         .username= current_user.full_name
@@ -12,3 +13,8 @@
         = link_to t('layouts.application.menu.logout'), logout_path, method: :post, class: 'login'
       - else
         = link_to t('layouts.application.menu.login'), login_path(redirect_to: request.path), class: 'login'
+.top-bar-search
+  .tts
+    = form_for @search || Search.new, url: search_path, html: {method: :get} do |form|
+      = form.text_field :query
+      = form.submit t('search.submit')

--- a/app/views/search/_form.html.haml
+++ b/app/views/search/_form.html.haml
@@ -1,0 +1,3 @@
+= form_for @search, url: search_path, html: {method: :get} do |form|
+  = form.text_field :query
+  = form.submit t('search.submit')

--- a/app/views/search/new.html.haml
+++ b/app/views/search/new.html.haml
@@ -1,0 +1,5 @@
+= semantic_form_for @search, url: search_path do |form|
+  = form.inputs do
+    != form.input :query
+  = form.actions do
+    != form.action :submit

--- a/app/views/search/new.html.haml
+++ b/app/views/search/new.html.haml
@@ -1,5 +1,0 @@
-= semantic_form_for @search, url: search_path do |form|
-  = form.inputs do
-    != form.input :query
-  = form.actions do
-    != form.action :submit

--- a/app/views/search/results.html.haml
+++ b/app/views/search/results.html.haml
@@ -1,4 +1,0 @@
-= @results.count
-- @results.each do |result|
-  = result.searchable_id
-  = result.searchable_type

--- a/app/views/search/results.html.haml
+++ b/app/views/search/results.html.haml
@@ -1,0 +1,4 @@
+= @results.count
+- @results.each do |result|
+  = result.searchable_id
+  = result.searchable_type

--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -1,0 +1,30 @@
+= render 'form'
+
+- if @results.nil? or @results.count == 0
+  %p
+    = t('search.no_results')
+- else
+  %p
+    = t('search.results', count: @results.count)
+  - @results.each do |result|
+    - item = result.searchable
+    .results
+      - if result.searchable_type == 'Event'
+        .event
+          .title
+            = link_to(item.title, item)
+            .time_place
+              = item.start_time
+              = " @ "
+              = item.area
+          .content
+            = truncate(item.short_description, length: 250)
+      - elsif result.searchable_type == 'Page'
+        .page
+          .title
+            = link_to(item.title, item)
+          .content
+            = truncate(item.content, length: 250)
+      %hr
+  .pagination
+    = will_paginate @results

--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -1,6 +1,6 @@
 = render 'form'
 
-- if @results.nil? or @results.count == 0
+- if @results.empty?
   %p
     = t('search.no_results')
 - else

--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -1,6 +1,6 @@
 = render 'form'
 
-- if @results.empty?
+- if @results.blank?
   %p
     = t('search.no_results')
 - else

--- a/config/authorization_rules.rb
+++ b/config/authorization_rules.rb
@@ -6,6 +6,9 @@ authorization do
     has_permission_on :member_sessions, to: :create
     has_permission_on :user_sessions, to: :create
 
+    # Search
+    has_permission_on :search, to: [:create, :search]
+
     # Password reset should not be protected.
     has_permission_on :applicants,
       to: [:forgot_password,

--- a/config/initializers/pg_search.rb
+++ b/config/initializers/pg_search.rb
@@ -1,0 +1,3 @@
+PgSearch.multisearch_options = {
+  :using => {tsearch: { prefix: true, dictionary: "english"}},
+}

--- a/config/locales/views/search/en.yml
+++ b/config/locales/views/search/en.yml
@@ -1,0 +1,8 @@
+en:
+  search:
+    results: 
+      one: "1 result"
+      other: "%{count} results"
+    no_results: "No results"
+    submit: "Search"
+

--- a/config/locales/views/search/no.yml
+++ b/config/locales/views/search/no.yml
@@ -1,0 +1,7 @@
+'no':
+  search:
+    results:
+      one: "Ett treff"
+      other: "%{count} treff"
+    no_results: "Ingen resultater"
+    submit: "Søk"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
   get 'contact', to: 'contact#index'
   post 'contact', to: 'contact#create'
 
+  get 'search', to: 'search#search'
+  #resources :search, only: [:new, :create, :search]
   ############################
   ##  Routes for events     ##
   ############################

--- a/db/migrate/20160408012345_create_pg_search_documents.rb
+++ b/db/migrate/20160408012345_create_pg_search_documents.rb
@@ -1,0 +1,18 @@
+class CreatePgSearchDocuments < ActiveRecord::Migration
+  def self.up
+    say_with_time("Creating table for pg_search multisearch") do
+      create_table :pg_search_documents do |t|
+        t.text :content
+        t.belongs_to :searchable, :polymorphic => true, :index => true
+        t.datetime :publish_at, null: false
+        t.timestamps null: false
+      end
+    end
+  end
+
+  def self.down
+    say_with_time("Dropping table for pg_search multisearch") do
+      drop_table :pg_search_documents
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160314172345) do
+ActiveRecord::Schema.define(:version => 20160408012345) do
 
   create_table "admissions", :force => true do |t|
     t.string   "title"
@@ -353,6 +353,15 @@ ActiveRecord::Schema.define(:version => 20160314172345) do
     t.integer  "applicant_id"
     t.datetime "created_at",    :null => false
     t.datetime "updated_at",    :null => false
+  end
+
+  create_table "pg_search_documents", :force => true do |t|
+    t.text     "content"
+    t.integer  "searchable_id"
+    t.string   "searchable_type"
+    t.datetime "publish_at",      :null => false
+    t.datetime "created_at",      :null => false
+    t.datetime "updated_at",      :null => false
   end
 
   create_table "price_groups", :force => true do |t|

--- a/lib/tasks/search_index.rake
+++ b/lib/tasks/search_index.rake
@@ -1,0 +1,16 @@
+task search_index: :environment do
+  puts "Deleting old index"
+  PgSearch::Document.delete_all
+  puts "Updating search index for events"
+  Event.find_each do |record|
+    record.update_pg_search_document
+    print '.'
+  end
+  print "\n"
+  puts "Updating search index for pages"
+  Page.find_each do |record|
+    record.update_pg_search_document
+    print '.'
+  end
+  print "\n"
+end


### PR DESCRIPTION
This commit uses features from the pg_search repo that allows for
additional attributes for multisearch. This enables multisearch to make
a filter based on theese attributes. In this commit this is used by
adding a publish_at field to search documents. This is to prevent events
that have yet to be published from being searchable.
