### PR TITLE
Switch Gemfile remotes from git to https

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,10 +69,10 @@ gem 'redcarpet'
 gem 'route_downcaser'
 
 # SamfundetDomain is a gem which provides the application with samfundets domain models.
-gem 'samfundet_domain', git: "git://github.com/Samfundet/SamfundetDomain.git"
+gem 'samfundet_domain', git: "https://github.com/Samfundet/SamfundetDomain.git"
 
 # SamfundetAuth is a gem which provides the application with methods for authenticating against mdb2.
-gem 'samfundet_auth', '~> 0.0.11', git: "git://github.com/Samfundet/SamfundetAuth.git"
+gem 'samfundet_auth', '~> 0.0.11', git: "https://github.com/Samfundet/SamfundetAuth.git"
 
 # will_paginate is an adaptive pagination plugin.
 # It makes pagination very simple.
@@ -166,7 +166,7 @@ group :development do
 
   # Simple command execution over SSH. Lightweight deployment tool.
   # Using our own version until https://github.com/mina-deploy/mina/pull/361 is merged.
-  gem 'mina', git: "git://github.com/Samfundet/mina.git"
+  gem 'mina', git: "https://github.com/Samfundet/mina.git"
 
   # A DSL for quickly creating web applications in Ruby with minimal effort.
   gem 'sinatra'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/Samfundet/SamfundetAuth.git
+  remote: https://github.com/Samfundet/SamfundetAuth.git
   revision: 3c9a3851694a22389b554d4182a947587b9c1ad4
   specs:
     samfundet_auth (0.0.11)
@@ -8,14 +8,14 @@ GIT
       rails (~> 3.2.8)
 
 GIT
-  remote: git://github.com/Samfundet/SamfundetDomain.git
+  remote: https://github.com/Samfundet/SamfundetDomain.git
   revision: cd5880b506c2c5425f32a09a3956e5b764ed263f
   specs:
     samfundet_domain (0.0.2)
       rails (~> 3.2.8)
 
 GIT
-  remote: git://github.com/Samfundet/mina.git
+  remote: https://github.com/Samfundet/mina.git
   revision: d8449b7b2cf3908361724b527d1ee4a05a698f97
   specs:
     mina (0.3.8)


### PR DESCRIPTION
As the git:// protocol is unsecured, we should use https instead.
