### PR TITLE
Add image pagination

### DIFF
--- a/app/assets/javascripts/events/select-image-modal.js
+++ b/app/assets/javascripts/events/select-image-modal.js
@@ -11,6 +11,12 @@ $(function () {
     $.modal.close();
   });
 
+  $(document).on('click', '.modal .pagination a', function(e) {
+    e.preventDefault();
+
+    $(".modal").load(this.href).open();
+  });
+
   $('.choose-image-link').on('click', function(e) {
     e.preventDefault();
     $(this).modal();

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -4,7 +4,8 @@ class ImagesController < ApplicationController
     if: -> { permitted_to? :edit, :images }
 
   def index
-    @images =  Image.all
+    @images = Image.paginate(page: params[:page], per_page: 10)
+
     if request.xhr?
       render layout: false
     end

--- a/app/views/images/_image_list.html.haml
+++ b/app/views/images/_image_list.html.haml
@@ -2,6 +2,7 @@
   - if @images.present?
     - @images.each do |image|
       = link_to image, class: 'image', data: { image: image.id, url: image.image_file.url } do
+        = "#{image.title}, tags: (#{image.tagstring})"
         = background_image_helper 'image-archive-image', image.image_file, size: :medium
   - else
     %p= t('search.no_results')

--- a/app/views/images/index.html.haml
+++ b/app/views/images/index.html.haml
@@ -10,3 +10,5 @@
 .ajax-results
 .existing-results
   = render 'image_list'
+
+= will_paginate @images


### PR DESCRIPTION
![suchawesome](https://cloud.githubusercontent.com/assets/1413365/14541538/afef230a-028a-11e6-9781-9041a339aa0e.PNG)

We now have pagination in our image lists!
This should improve the user experience of adding pictures to events significantly, as you no longer have to load _all_ the pictures just to view the first 8.
