### PR TITLE
Fix Norwegian translation for information on events

### DIFF
--- a/config/locales/views/events/en.yml
+++ b/config/locales/views/events/en.yml
@@ -27,6 +27,11 @@ en:
     add_price_group: Add price group
     remove_price_group: Remove this price group
 
+    age_limit: Age limit
+    area: Area
+    organizer: Organizer
+    ticket: Ticket
+
     concert: Concert
     quiz: Quiz
     theater: Theater

--- a/config/locales/views/events/no.yml
+++ b/config/locales/views/events/no.yml
@@ -29,10 +29,8 @@
 
     age_limit: Aldersgrense
     area: Lokale
-    event_type: Type
     organizer: Arrangør
     ticket: Billett
-    status: Status
 
     concert: Konsert
     quiz: Quiz

--- a/config/locales/views/events/no.yml
+++ b/config/locales/views/events/no.yml
@@ -27,6 +27,13 @@
     add_price_group: Legg til prisgruppe
     remove_price_group: Slett denne prisgruppen
 
+    age_limit: Aldersgrense
+    area: Lokale
+    event_type: Type
+    organizer: Arrangør
+    ticket: Billett
+    status: Status
+
     concert: Konsert
     quiz: Quiz
     theater: Teater


### PR DESCRIPTION
When correct translations were added to the form, the labels were moved to the form, which removed the translations for the main event page. This is now fixed.
