### PR TITLE
Quickfix for unknown local variable post path

### DIFF
--- a/app/views/events/_search_form.html.haml
+++ b/app/views/events/_search_form.html.haml
@@ -1,3 +1,4 @@
+- post_path = search_events_path if local_assigns[:post_path].nil?
 = form_tag post_path, method: :get, class: 'custom-form search-form', autocomplete: 'off' do
   = search_field_tag 'search', nil, placeholder: t('events.search.title')
   = select_tag 'event_type', options_for_select(Event::EVENT_TYPE.map { |k| [t("events.#{k}"), k] }.sort_by &:first), prompt: t('events.search.type'), class: 'search-constraints'


### PR DESCRIPTION
Fixes error with the local variable post_path not being set if javascript is disabled. Event search should be rewritten, see #92 
