### PR TITLE
Send exception mails to mg-web-error instead of mg-web-intern

### DIFF
--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -18,7 +18,7 @@ ExceptionNotification.configure do |config|
     config.add_notifier :email, {
       email_prefix: "[ERROR] ",
       sender_address: %{"Notifier" <no-reply@samfundet.no>},
-      exception_recipients: %w{mg-web-intern@samfundet.no},
+      exception_recipients: %w{mg-web-error@samfundet.no},
       sections: %w{request backtrace}
     }
 


### PR DESCRIPTION
To everyone retired; no more spam!
