### PR TITLE
Add typeahead search to applicant steal identity applet

### DIFF
--- a/app/assets/javascripts/old_samfundet/global.js
+++ b/app/assets/javascripts/old_samfundet/global.js
@@ -62,6 +62,11 @@ $(function() { // Called when document is fully loaded
     source: "/en/members/search.json",
     minChars: 3
   });
+
+  $("input.applicant_autocomplete").autocomplete({
+    source: "/en/applicants/search.json",
+    minChars: 3
+  });
 });
 
 // Tablesorter

--- a/app/assets/stylesheets/sitewide/_flashes.css.scss
+++ b/app/assets/stylesheets/sitewide/_flashes.css.scss
@@ -17,4 +17,8 @@
     &.message {
         background-color: $samfundet-purple;
     }
+
+    &.notice {
+        background-color: $samfundet-orange;
+    }
 }

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -127,9 +127,35 @@ class ApplicantsController < ApplicationController
   end
 
   def steal_identity
-    session[:member_id] = nil
-    session[:applicant_id] = Applicant.find_by_email(params[:applicant_email].downcase).id
-    redirect_to root_path
+    applicant = Applicant.find(params[:applicant_id])
+    if applicant.nil?
+      redirect_to members_control_panel_path, notice: "Fant ikke søker"
+    else
+      session[:member_id] = nil
+      session[:applicant_id] = applicant.id
+      redirect_to root_path
+    end
+  end
+
+  def search
+    @applicants = Applicant.where(
+      "UPPER(firstname) || ' ' || UPPER(surname) LIKE UPPER(?)" \
+      " OR UPPER(email) LIKE UPPER(?) OR id = ?",
+      "%#{params[:term].upcase}%",
+      "%#{params[:term].upcase}%",
+      params[:term].to_i
+    )
+
+    respond_to do |format|
+      format.json do
+        # Note the parentheses; they're necessary to achieve
+        # the correct precedence for the do-block.
+        render json: (@applicants.map do |applicant|
+          { value: "#{applicant.id} - #{applicant.full_name}",
+            label: "#{applicant.full_name} (#{applicant.email})" }
+        end)
+      end
+    end
   end
 
   private

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -9,11 +9,13 @@ class MembersController < ApplicationController
                            if: -> { true }
 
   def search
-    @members = Member.where("UPPER(fornavn) || ' ' || UPPER(etternavn) LIKE UPPER(?)" +
-                            " OR UPPER(mail) LIKE UPPER(?) OR medlem_id = ?",
-                            "%#{params[:term].upcase}%",
-                            "%#{params[:term].upcase}%",
-                            params[:term].to_i)
+    @members = Member.where(
+      "UPPER(fornavn) || ' ' || UPPER(etternavn) LIKE UPPER(?)" \
+      " OR UPPER(mail) LIKE UPPER(?) OR medlem_id = ?",
+      "%#{params[:term].upcase}%",
+      "%#{params[:term].upcase}%",
+      params[:term].to_i
+    )
 
     respond_to do |format|
       format.json do

--- a/app/views/applicants/_steal_identity_applet.html.haml
+++ b/app/views/applicants/_steal_identity_applet.html.haml
@@ -1,6 +1,6 @@
 %h2= t("applicants.steal_identity")
 = form_tag applicants_steal_identity_path, method: "post", class: "custom-form" do
   %p
-    = text_field_tag :applicant_email, nil, placeholder: t("applicants.search_placeholder"), class: "textfield", required: true
+    = text_field_tag :applicant_id, nil, placeholder: t("applicants.search_placeholder"), class: "textfield applicant_autocomplete", required: true
   %p
     = submit_tag t("applicants.steal_identity_button")

--- a/config/locales/views/applicants/en.yml
+++ b/config/locales/views/applicants/en.yml
@@ -18,7 +18,7 @@ en:
     suspicious_phone_number_html: "You entered<strong>%{phone}</strong> as your phone number. This number has a format we don't recognize; please ensure that it's correct. <a href='%{url}'>Click here to change your phone number.</a>"
     steal_identity: "Steal applicant's identity"
     steal_identity_button: "Steal identity"
-    search_placeholder: "Applicant's e-mail"
+    search_placeholder: "Name/ID/Email"
     interested_other_positions_hint: "Are you interested in being offered other positions beyond the ones you will apply to?"
     forms:
       register:

--- a/config/locales/views/applicants/no.yml
+++ b/config/locales/views/applicants/no.yml
@@ -18,7 +18,7 @@
     suspicious_phone_number_html: "Du oppgav <strong>%{phone}</strong> som ditt telefonnummer. Dette nummeret har et format vi ikke gjenkjenner; vennligst sjekk at det er riktig. <a href='%{url}'>Klikk her for å endre nummeret.</a>"
     steal_identity: "Stjel identitet til søker"
     steal_identity_button: "Stjel identitet"
-    search_placeholder: "E-post til søker"
+    search_placeholder: "Navn/ID/Epost"
     interested_other_positions_hint: "Er du interessert i å få tilbud om andre stillinger enn de du søker på?"
     forms:
       register:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,6 +100,8 @@ Rails.application.routes.draw do
     match "reset_password" => "applicants#reset_password"
   end
 
+  match "applicants/search" => "applicants#search",
+        as: :applicant_search
   resources :applicants
   resources :groups, only: [:new, :create, :edit, :update] do
     get :admin, on: :collection


### PR DESCRIPTION
This adds the same feature on member steal identity to applicant steal identity applet.
