### PR TITLE
Break long words on frontpage

### DIFF
--- a/app/assets/stylesheets/site/_upcoming_events.css.scss
+++ b/app/assets/stylesheets/site/_upcoming_events.css.scss
@@ -61,6 +61,10 @@
 
         a { @include emph-link($samfundet-red); }
 
+        @include media($mobile){
+          word-break: break-all;
+        }
+
         @include media($tablet-desktop) {
           white-space: nowrap;
           overflow: hidden;

--- a/app/assets/stylesheets/site/_upcoming_events.css.scss
+++ b/app/assets/stylesheets/site/_upcoming_events.css.scss
@@ -61,7 +61,7 @@
 
         a { @include emph-link($samfundet-red); }
 
-        @include media($mobile){
+        @include media($mobile) {
           word-break: break-all;
         }
 


### PR DESCRIPTION
Fixes #146 crudely.

Hyphens did not work, so this became the solution.
