### PR TITLE
Make adaptation text less intensive

### DIFF
--- a/app/assets/stylesheets/events/events.css.scss
+++ b/app/assets/stylesheets/events/events.css.scss
@@ -87,7 +87,8 @@
         }
 
         p.adaptation {
-          font-weight: 500;
+          font-style: italic;
+          font-size: 17px;
         }
 
         .social {


### PR DESCRIPTION
This is how the adaptation text looks like now, and some people find this too big and looks like the main information for the event.
![image](https://cloud.githubusercontent.com/assets/8659151/19363511/162d4c98-918b-11e6-8742-0870b8c7269e.png)

It was an idea to change this with an HC symbol like this
![image](https://cloud.githubusercontent.com/assets/8659151/19363552/453db2a2-918b-11e6-8624-e64dc6a5f9a2.png)

But this again made it look kind of awkward when no other symbols were there
![image](https://cloud.githubusercontent.com/assets/8659151/19363606/5d280caa-918b-11e6-87be-165921144f9b.png)

Therefore just changing the text to a smaller one with italic style looks like the best solution. This is a personal opinion and the pictures are added if someone disagrees with the solution and want to see what else can be done
![image](https://cloud.githubusercontent.com/assets/8659151/19363652/9a75cff2-918b-11e6-8add-0df6dd1df68b.png)

k thnx bye
