### PR TITLE
Remove lock outdated events

### DIFF
--- a/app/models/front_page_lock.rb
+++ b/app/models/front_page_lock.rb
@@ -27,7 +27,7 @@ class FrontPageLock < ActiveRecord::Base
   # end
 
   def self.locks_enabled
-    where('lockable_id IS NOT null').reject { |a| a.lockable_type == "Event" && a.lockable.end_time < DateTime.current - 2 / 24.0 }
+    where('lockable_id IS NOT null').reject { |a| a.lockable_type == "Event" && a.lockable.end_time < 2.hours.from_now }
   end
 
   def to_param

--- a/app/models/front_page_lock.rb
+++ b/app/models/front_page_lock.rb
@@ -27,7 +27,6 @@ class FrontPageLock < ActiveRecord::Base
   # end
 
   def self.locks_enabled
-    # Returns events that has not ended yet (with 2 hours of wiggle room)
     where('lockable_id IS NOT null').reject { |a| a.lockable_type == "Event" && a.lockable.end_time < DateTime.current - 2.hours.from_now }
   end
 

--- a/app/models/front_page_lock.rb
+++ b/app/models/front_page_lock.rb
@@ -27,7 +27,7 @@ class FrontPageLock < ActiveRecord::Base
   # end
 
   def self.locks_enabled
-    where('lockable_id IS NOT null').reject { |a| a.lockable_type == "Event" && a.lockable.end_time < DateTime.current - 2.hours.from_now }
+    where('lockable_id IS NOT null').reject { |a| a.lockable_type == "Event" && a.lockable.end_time < DateTime.current - 2 / 24.0 }
   end
 
   def to_param

--- a/app/models/front_page_lock.rb
+++ b/app/models/front_page_lock.rb
@@ -28,7 +28,7 @@ class FrontPageLock < ActiveRecord::Base
 
   def self.locks_enabled
     # Returns locks where the event has not ended two hours ago
-    return locks = where('lockable_id IS NOT null').reject { |a| a.lockable.end_time < DateTime.current - 2 / 24.0 }
+    where('lockable_id IS NOT null').reject { |a| a.lockable.end_time < DateTime.current - 2.hours.from_now }
   end
 
   def to_param

--- a/app/models/front_page_lock.rb
+++ b/app/models/front_page_lock.rb
@@ -15,11 +15,6 @@ class FrontPageLock < ActiveRecord::Base
                          message: "Invalid lock type",
                          if: :lockable_type?
 
-  scope :locks_enabled, -> {
-    where('lockable_id IS NOT null')
-      .order(:position)
-  }
-
   # TODO: this might not be an issue in rails 3
   # belongs_to touch: true does not currently touch the old associated
   # object when the foreign key is the value that changes.
@@ -30,6 +25,21 @@ class FrontPageLock < ActiveRecord::Base
   #    lockable_was.touch
   #  end
   # end
+
+  def self.locks_enabled
+    locks = self.where('lockable_id IS NOT null')
+    enabled_locks = Set.new []
+    for lock in locks
+      puts "LOLOL"
+      puts DayTime
+      puts lock.lockable.end_time
+      puts DayTime < lock.lockable.end_time
+      if lock.lockable_type == "Event" && DayTime < lock.lockable.end_time
+        enabled_locks.add(lock)
+      end
+    end
+    return enabled_locks
+  end
 
   def to_param
     position

--- a/app/models/front_page_lock.rb
+++ b/app/models/front_page_lock.rb
@@ -27,8 +27,8 @@ class FrontPageLock < ActiveRecord::Base
   # end
 
   def self.locks_enabled
-    # Returns locks where the event has not ended two hours ago
-    where('lockable_id IS NOT null').reject { |a| a.lockable.end_time < DateTime.current - 2.hours.from_now }
+    # Returns events that has not ended yet (with 2 hours of wiggle room)
+    where('lockable_id IS NOT null').reject { |a| a.lockable_type == "Event" && a.lockable.end_time < DateTime.current - 2.hours.from_now }
   end
 
   def to_param

--- a/app/models/front_page_lock.rb
+++ b/app/models/front_page_lock.rb
@@ -30,11 +30,8 @@ class FrontPageLock < ActiveRecord::Base
     locks = self.where('lockable_id IS NOT null')
     enabled_locks = Set.new []
     for lock in locks
-      puts "LOLOL"
-      puts DayTime
-      puts lock.lockable.end_time
-      puts DayTime < lock.lockable.end_time
-      if lock.lockable_type == "Event" && DayTime < lock.lockable.end_time
+      #Removes the lock if the event end time + 2 hours has passed
+      if lock.lockable_type == "Event" && (DateTime.now-2/24.0) < lock.lockable.end_time
         enabled_locks.add(lock)
       end
     end

--- a/app/models/front_page_lock.rb
+++ b/app/models/front_page_lock.rb
@@ -27,15 +27,8 @@ class FrontPageLock < ActiveRecord::Base
   # end
 
   def self.locks_enabled
-    locks = self.where('lockable_id IS NOT null')
-    enabled_locks = Set.new []
-    for lock in locks
-      #Removes the lock if the event end time + 2 hours has passed
-      if lock.lockable_type == "Event" && (DateTime.now-2/24.0) < lock.lockable.end_time
-        enabled_locks.add(lock)
-      end
-    end
-    return enabled_locks
+    # Returns locks where the event has not ended two hours ago
+    return locks = where('lockable_id IS NOT null').reject { |a| a.lockable.end_time < DateTime.current - 2 / 24.0 }
   end
 
   def to_param


### PR DESCRIPTION
Should remove the events that have expired from the set that it returns.
