### PR TITLE
Archived events link

### DIFF
--- a/app/assets/stylesheets/events/events.css.scss
+++ b/app/assets/stylesheets/events/events.css.scss
@@ -164,15 +164,13 @@
     }
 
     .bottom-links {
-        table {
-            width: 100%;
-            text-align: center;
-            tr {
-                td {
-                    text-align: center;
-                    font-weight: bold;
-                }
-            }
+        display: table;
+        width: 100%;
+        table-layout: fixed;
+        span {
+          display: table-cell;
+          text-align: center;
+          font-weight: bold;
         }
     }
 

--- a/app/assets/stylesheets/events/events.css.scss
+++ b/app/assets/stylesheets/events/events.css.scss
@@ -174,7 +174,7 @@
         height: 40px;
         width: 40px;
 
-        background-position: center; 
+        background-position: center;
         background-repeat: no-repeat;
         background-size: 40px;
 
@@ -185,11 +185,17 @@
         &.ical-icon {
           background-image: url(calendar.svg);
         }
-        
+
         &.archive-icon {
           background-image: url(archive.svg);
         }
       }
+    }
+
+    .link-table {
+      border: none;
+      cellspacing: 0;
+      cellpadding: 0;
     }
 
     .event-group {

--- a/app/assets/stylesheets/events/events.css.scss
+++ b/app/assets/stylesheets/events/events.css.scss
@@ -169,9 +169,6 @@
         text-align: center;
         table-layout: fixed;
 
-        white-space: nowrap;
-        text-align: center;
-
         a{
           display: table-cell;
         }

--- a/app/assets/stylesheets/events/events.css.scss
+++ b/app/assets/stylesheets/events/events.css.scss
@@ -163,39 +163,17 @@
         }
     }
 
-    .links {
-      text-align: center;
-      a {
-        display: inline-block;
-
-        margin: auto;
-        padding: 40px;
-
-        height: 40px;
-        width: 40px;
-
-        background-position: center;
-        background-repeat: no-repeat;
-        background-size: 40px;
-
-        &.rss-icon {
-          background-image: url(rss.svg);
+    .bottom-links {
+        table {
+            width: 100%;
+            text-align: center;
+            tr {
+                td {
+                    text-align: center;
+                    font-weight: bold;
+                }
+            }
         }
-
-        &.ical-icon {
-          background-image: url(calendar.svg);
-        }
-
-        &.archive-icon {
-          background-image: url(archive.svg);
-        }
-      }
-    }
-
-    .link-table {
-      border: none;
-      cellspacing: 0;
-      cellpadding: 0;
     }
 
     .event-group {

--- a/app/assets/stylesheets/events/events.css.scss
+++ b/app/assets/stylesheets/events/events.css.scss
@@ -171,14 +171,22 @@
 
         white-space: nowrap;
         text-align: center;
-        span{
+
+        a{
           display: table-cell;
         }
 
         img{
           width: 40px;
+          position: relative;
+          top: 9px;
         }
 
+        @include media($mobile-and-tablet-portrait) {
+          a{
+            display: table-row;
+          }
+        }
     }
 
     .event-group {

--- a/app/assets/stylesheets/events/events.css.scss
+++ b/app/assets/stylesheets/events/events.css.scss
@@ -177,9 +177,10 @@
         }
 
         img{
-          width: 40px;
+          width: 2em;
           position: relative;
-          top: 9px;
+          top: 0.5em;
+          right: 0.5em;
         }
 
         @include media($mobile-and-tablet-portrait) {

--- a/app/assets/stylesheets/events/events.css.scss
+++ b/app/assets/stylesheets/events/events.css.scss
@@ -166,12 +166,19 @@
     .bottom-links {
         display: table;
         width: 100%;
+        text-align: center;
         table-layout: fixed;
-        span {
+
+        white-space: nowrap;
+        text-align: center;
+        span{
           display: table-cell;
-          text-align: center;
-          font-weight: bold;
         }
+
+        img{
+          width: 40px;
+        }
+
     }
 
     .event-group {

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -11,13 +11,13 @@
           %tbody
             = render events.sort_by{|event| event.start_time}
 
-    %table{style:'border:none !important; cellspacing:0; cellpadding:0'}
-      %tbody
-        %tr
-          .links
-            %td.archive{style:'text-align:center; font-weight:bold; border:none'}
+    .bottom-links
+      %table.custom-table
+        %tbody
+          %tr
+            %td.archive
               = link_to t('events.archive.title'), archive_events_path
-            %td.rss{style:'text-align:center; font-weight:bold; border:none'}
+            %td.rss
               = link_to t('events.rss_alt_text'), '/rss'
-            %td.calendar{style:'text-align:center; font-weight:bold'}
+            %td.calendar
               = link_to t('events.ical_alt_text'), '/arrangement/ical'

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -12,9 +12,15 @@
             = render events.sort_by{|event| event.start_time}
 
   .bottom-links
-    %span.archive
-      = link_to t('events.archive.title'), archive_events_path
-    %span.rss
-      = link_to t('events.rss_short_text'), '/rss'
-    %span.calendar
-      = link_to t('events.ical_short_text'), '/arrangement/ical'
+    %span
+      %a{ href: archive_events_path, title: t('events.archive.title')}
+        = image_tag("archive.svg")
+        = t('events.archive.title')
+    %span
+      %a{ href: '/rss', title: t('events.rss_alt_text')}
+        = image_tag("rss.svg")
+        = t('events.rss_short_text')
+    %span
+      %a{ href: '/arrangement/ical', title: t('events.ical_alt_text')}
+        = image_tag("calendar.svg")
+        = t('events.ical_short_text')

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -11,13 +11,10 @@
           %tbody
             = render events.sort_by{|event| event.start_time}
 
-    .bottom-links
-      %table.custom-table
-        %tbody
-          %tr
-            %td.archive
-              = link_to t('events.archive.title'), archive_events_path
-            %td.rss
-              = link_to t('events.rss_alt_text'), '/rss'
-            %td.calendar
-              = link_to t('events.ical_alt_text'), '/arrangement/ical'
+  .bottom-links
+    %span.archive
+      = link_to t('events.archive.title'), archive_events_path
+    %span.rss
+      = link_to t('events.rss_short_text'), '/rss'
+    %span.calendar
+      = link_to t('events.ical_short_text'), '/arrangement/ical'

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -12,15 +12,12 @@
             = render events.sort_by{|event| event.start_time}
 
   .bottom-links
-    %span
-      %a{ href: archive_events_path, title: t('events.archive.title')}
-        = image_tag("archive.svg")
-        = t('events.archive.title')
-    %span
-      %a{ href: '/rss', title: t('events.rss_alt_text')}
-        = image_tag("rss.svg")
-        = t('events.rss_short_text')
-    %span
-      %a{ href: '/arrangement/ical', title: t('events.ical_alt_text')}
-        = image_tag("calendar.svg")
-        = t('events.ical_short_text')
+    %a{ href: archive_events_path, title: t('events.archive.title')}
+      = image_tag("archive.svg")
+      = t('events.archive.title')
+    %a{ href: '/rss', title: t('events.rss_alt_text')}
+      = image_tag("rss.svg")
+      = t('events.rss_short_text')
+    %a{ href: '/arrangement/ical', title: t('events.ical_alt_text')}
+      = image_tag("calendar.svg")
+      = t('events.ical_short_text')

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -11,7 +11,13 @@
           %tbody
             = render events.sort_by{|event| event.start_time}
 
-  .links
-    %a.rss-icon{ href: '/rss', title: t('events.rss_alt_text')}
-    %a.ical-icon{ href: '/arrangement/ical', title: t('events.ical_alt_text')}
-    %a.archive-icon{ href: archive_events_path, title: t('events.archive.title')}    
+    %table{style:'border:none !important; cellspacing:0; cellpadding:0'}
+      %tbody
+        %tr
+          .links
+            %td.archive{style:'text-align:center; font-weight:bold; border:none'}
+              = link_to t('events.archive.title'), archive_events_path
+            %td.rss{style:'text-align:center; font-weight:bold; border:none'}
+              = link_to t('events.rss_alt_text'), '/rss'
+            %td.calendar{style:'text-align:center; font-weight:bold'}
+              = link_to t('events.ical_alt_text'), '/arrangement/ical'

--- a/config/locales/views/events/en.yml
+++ b/config/locales/views/events/en.yml
@@ -1,8 +1,10 @@
 en:
   events:
     rss_title: Events at Studentersamfundet in Trondheim
-    rss_alt_text: Samfundets rss strøm.
-    ical_alt_text: Samfundets ical strøm.
+    rss_alt_text: Samfundet's rss feed.
+    rss_short_text: RSS
+    ical_alt_text: Samfundet's ical feed.
+    ical_short_text: iCal
     create_success: Successfully created the event.
     create_error: Could not create event.
     update_success: Successfully updated the event.

--- a/config/locales/views/events/en.yml
+++ b/config/locales/views/events/en.yml
@@ -1,9 +1,9 @@
 en:
   events:
     rss_title: Events at Studentersamfundet in Trondheim
-    rss_alt_text: Samfundet's rss feed.
+    rss_alt_text: Samfundet's RSS feed.
     rss_short_text: RSS
-    ical_alt_text: Samfundet's ical feed.
+    ical_alt_text: Samfundet's iCal feed.
     ical_short_text: iCal
     create_success: Successfully created the event.
     create_error: Could not create event.

--- a/config/locales/views/events/no.yml
+++ b/config/locales/views/events/no.yml
@@ -1,9 +1,9 @@
 'no':
   events:
     rss_title: Arrangementer på Studentersamfundet i Trondhjem
-    rss_alt_text: Samfundets rss feed.
+    rss_alt_text: Samfundets RSS feed.
     rss_short_text: RSS
-    ical_alt_text: Samfundets ical feed.
+    ical_alt_text: Samfundets iCal feed.
     ical_short_text: iCal
     create_success: Arrangementet er opprettet.
     create_error: Arrangementet ble ikke opprettet.


### PR DESCRIPTION
The bottom links now look like this: 
![image](https://cloud.githubusercontent.com/assets/14058300/21996825/50ad6290-dc2c-11e6-8b3d-8578f9798772.png)
This should be more intuitive for the user. 

Fixes #190 