### PR TITLE
Use static default timestamp for members roles

### DIFF
--- a/db/migrate/20170126195339_add_timestamp_to_members_role.rb
+++ b/db/migrate/20170126195339_add_timestamp_to_members_role.rb
@@ -1,6 +1,6 @@
 class AddTimestampToMembersRole < ActiveRecord::Migration
   def change
-    add_column :members_roles, :created_at, :datetime, null: false, default: DateTime.now
-    add_column :members_roles, :updated_at, :datetime, null: false, default: DateTime.now
+    add_column :members_roles, :created_at, :datetime, null: false, default: '2017-01-26 21:50:05'
+    add_column :members_roles, :updated_at, :datetime, null: false, default: '2017-01-26 21:50:05'
   end
 end


### PR DESCRIPTION
When `DateTime.now` was used, the `schema.rb` would be updated with a different timestamp by everyone running the migration, resulting in unintended changes. 

This is fixed by setting the default value to a static timestamp, in this case `2017-01-26 21:50:05`.