### PR TITLE
Increase rubocop max. class length

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -75,7 +75,7 @@ Metrics/AbcSize:
 # Offense count: 4
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 350
+  Max: 400
 
 # Offense count: 6
 Metrics/CyclomaticComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -75,7 +75,7 @@ Metrics/AbcSize:
 # Offense count: 4
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 228
+  Max: 350
 
 # Offense count: 6
 Metrics/CyclomaticComplexity:


### PR DESCRIPTION
Increase Rubocop's max. class length from 228 to 400 lines to avoid failing Travis builds.