### PR TITLE
Handle missing search parameters in events archive search

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -41,9 +41,10 @@ class EventsController < ApplicationController
 
   def archive_search
     # Save the search parameters as instance variables
-    @search = params[:search]
-    @event_type = params[:event_type]
-    @event_area = params[:event_area]
+    # Convert each param to string in case it is nil
+    @search = params[:search].to_s
+    @event_type = params[:event_type].to_s
+    @event_area = params[:event_area].to_s
 
     @events, @event_types, @event_areas = Event.archived_events_types_areas
     @events = @events.text_search(@search + ' ' + @event_type + ' ' + @event_area)

--- a/config/locales/routes/i18n-routes.yml
+++ b/config/locales/routes/i18n-routes.yml
@@ -43,6 +43,7 @@
     contactinfo: kontaktinfo
     reject_calls: sokere-dere-skal-ringe
     one_year_old: mer-enn-ett-aar-gamle-roller
+    archive_search: arkivsok
 
 en:
   routes:


### PR DESCRIPTION
All search parameters are passed to the controller as `String` when searching from the archive view.

This is not the case when posting directly to the controller method, e.g. `../archive_search`. In this case, the missing search parameters are `nil` instead of `String`, and the search method fails.

This is fixed by converting all the search parameters to `String` before searching.

In addition to this, the Norwegian route translation has been created.

