### PR TITLE
Remove unnecessary join of tables

### DIFF
--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -74,7 +74,7 @@ class RolesController < ApplicationController
   end
 
   def one_year_old
-    @older_than_one_year = MembersRole.joins(:member, :role).where("members_roles.created_at < ?", 1.year.ago)
+    @older_than_one_year = MembersRole.where("members_roles.created_at < ?", 1.year.ago)
   end
 
   protected


### PR DESCRIPTION
One can still access MembersRoles member and role from the role itself, so there is no use for joining the two tables first. 