### PR TITLE
Disable search engine indexing on successful ticket purchase page.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,6 +3,12 @@
 module ApplicationHelper
   FLASH_TYPES = [:success, :notice, :error, :message, :warning].freeze
 
+  def disable_robots
+    content_for(:head) do
+      haml_tag :meta, { name: 'robots', content: 'noindex' }
+    end
+  end
+
   def set_title(page_title)
     content_for(:title) { page_title }
   end

--- a/app/views/events/purchase_callback_success.html.haml
+++ b/app/views/events/purchase_callback_success.html.haml
@@ -1,3 +1,5 @@
+- disable_robots
+
 %h2
   = t('events.purchase_callback_success.title')
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -3,6 +3,7 @@
   %head
     %meta{ charset: "UTF-8" }
     %meta{ name: "viewport", content: "width=device-width, initial-scale=1.0" }
+    != yield :head
     %title
       - unless (yield :title).blank?
         #{yield(:title)} - 
@@ -20,7 +21,6 @@
     %meta{ name:"twitter:site", content:"@Samfundet"}
     %meta{ name:"twitter:creator", content:"@Samfundet"}
     = yield :twitter
-    != yield :head
 
   %body{ class: ('dev-filter' unless Rails.env.production?) }
     #sticky-footer-wrapper


### PR DESCRIPTION
`purchase_callback_success.html.haml` is currently being indexed by some search engines. Thus, a metatag has been added to explicitly tell crawlers to avoid indexing this page.