### PR TITLE
Remove ticket ribbons from archived events

### DIFF
--- a/app/views/events/_corner_ribbon.html.haml
+++ b/app/views/events/_corner_ribbon.html.haml
@@ -1,19 +1,20 @@
-- if event.few_tickets_left? && event.ticket_limit?
-  .ribbon-long-wrapper
-    .ribbon.red
-      = t('site.index.few_tickets_left')
+- if event.purchase_status != Event::TICKETS_UNAVAILABLE
+  - if event.few_tickets_left? && event.ticket_limit?
+    .ribbon-long-wrapper
+      .ribbon.red
+        = t('site.index.few_tickets_left')
 
-  .ribbon-short-wrapper
-    .ribbon.blue
-      = t('site.index.max_ticket_limit_short', total_ticket_limit: event.total_ticket_limit)
+    .ribbon-short-wrapper
+      .ribbon.blue
+        = t('site.index.max_ticket_limit_short', total_ticket_limit: event.total_ticket_limit)
 
-- elsif event.few_tickets_left?
-  .ribbon-long-wrapper
-    .ribbon.red
-      = t('site.index.few_tickets_left')
+  - elsif event.few_tickets_left?
+    .ribbon-long-wrapper
+      .ribbon.red
+        = t('site.index.few_tickets_left')
 
-- elsif event.ticket_limit?
-  - pluralize = event.total_ticket_limit > 1 ? 'multiple' : 'single'
-  .ribbon-long-wrapper
-    .ribbon.blue
-      = t("site.index.max_ticket_limit_#{pluralize}_long", total_ticket_limit: event.total_ticket_limit)
+  - elsif event.ticket_limit?
+    - pluralize = event.total_ticket_limit > 1 ? 'multiple' : 'single'
+    .ribbon-long-wrapper
+      .ribbon.blue
+        = t("site.index.max_ticket_limit_#{pluralize}_long", total_ticket_limit: event.total_ticket_limit)


### PR DESCRIPTION
Archived events are currently rendered with ticket ribbons (i.e. "Få billetter igjen" and "Maks. x") in the event header image. 

I believe this information is superfluous for an archived event, and this PR removes these ribbons from such events. 