### PR TITLE
Fix member role timestamp

### DIFF
--- a/db/migrate/20170817174432_fix_member_role_timestamp.rb
+++ b/db/migrate/20170817174432_fix_member_role_timestamp.rb
@@ -1,0 +1,6 @@
+class FixMemberRoleTimestamp < ActiveRecord::Migration
+  def change
+  	change_column_default :members_roles, :created_at, nil
+  	change_column_default :members_roles, :updated_at, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20170204193734) do
+ActiveRecord::Schema.define(:version => 20170817174432) do
 
   create_table "admissions", :force => true do |t|
     t.string   "title"
@@ -332,8 +332,8 @@ ActiveRecord::Schema.define(:version => 20170204193734) do
   create_table "members_roles", :force => true do |t|
     t.integer  "member_id"
     t.integer  "role_id"
-    t.datetime "created_at", :default => '2017-02-04 19:41:44', :null => false
-    t.datetime "updated_at", :default => '2017-02-04 19:41:44', :null => false
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
   end
 
   create_table "page_revisions", :force => true do |t|
@@ -462,14 +462,6 @@ ActiveRecord::Schema.define(:version => 20170204193734) do
 
   create_table "tags", :force => true do |t|
     t.string   "name"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
-  end
-
-  create_table "users", :force => true do |t|
-    t.string   "name"
-    t.string   "email"
-    t.string   "login"
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
   end


### PR DESCRIPTION
The default value of the member role columns 'created_at', and 'updated_at' was set to january 30th. This should now correctly show the time they were created at and updated at.