### PR TITLE
Unified edit and admin_new form

### DIFF
--- a/app/controllers/sulten/reservations_controller.rb
+++ b/app/controllers/sulten/reservations_controller.rb
@@ -1,5 +1,5 @@
 class Sulten::ReservationsController < ApplicationController
-  filter_access_to [:archive, :export, :admin_new, :admin_create], require: :manage
+  filter_access_to [:archive, :export, :admin_new, :edit, :admin_create], require: :manage
 
   def index
     @reservations = Sulten::Reservation.where(reservation_from: Time.now.beginning_of_week..Time.now.end_of_week).order("reservation_from")

--- a/app/views/sulten/reservations/admin_new.html.haml
+++ b/app/views/sulten/reservations/admin_new.html.haml
@@ -8,14 +8,15 @@
   <a href="mailto:lyche@samfundet.no">Lyche.</a>
 = semantic_form_for @reservation, url: "/lyche/reservasjon_admin" do |f|
   = f.inputs do
+    = f.input :table_id, label: t("sulten.table.admin_select"), as: :select, collection: Sulten::Table.where(available: true)
     = f.input :people, label: t("sulten.reservation.people"),as: :number
     = f.input :reservation_from, placeholder: t("sulten.reservation.placeholder_date"), label: t("sulten.reservation.form.from"), input_html: { class: "datetimepicker_lyche"}, as: :string
     = f.input :reservation_duration, label: t("sulten.reservation.form.duration"), collection: [30, 60, 90, 120, 180], member_label: proc{|d| "#{d} minutter"}, include_blank: false, selected: 120
     = f.input :name, label: t("sulten.reservation.name")
     = f.input :reservation_type, label: t("sulten.reservation.reservation_type"), include_blank: false
-    = f.input :table_id, label: t("sulten.table.admin_select"), as: :select, collection: Sulten::Table.where(available: true)
     = f.input :telephone, label: t("sulten.reservation.telephone")
     = f.input :email, label: t("sulten.reservation.email")
     = f.input :allergies, label: t("sulten.reservation.allergies")
+    = f.input :internal_comment, label: t("sulten.reservation.internal_comment")
   = f.actions do
     = f.submit t("sulten.reservation.form.create")

--- a/app/views/sulten/reservations/edit.html.haml
+++ b/app/views/sulten/reservations/edit.html.haml
@@ -3,7 +3,7 @@
     = f.input :table, label: t("sulten.reservation.table")
     = f.input :people, label: t("sulten.reservation.people"),as: :number
     = f.input :reservation_from, label: t("sulten.reservation.form.from"), input_html: { class: "datetimepicker_lyche"}, as: :string, input_html: { value: @reservation.reservation_from.to_s }
-    = f.input :reservation_duration, label: t("sulten.reservation.form.duration"), collection: [30, 60, 90, 120], member_label: proc{|d| "#{d} minutter"}, include_blank: false
+    = f.input :reservation_duration, label: t("sulten.reservation.form.duration"), collection: [30, 60, 90, 120, 180], member_label: proc{|d| "#{d} minutter"}, include_blank: false
     = f.input :name, label: t("sulten.reservation.name")
     = f.input :reservation_type, label: t("sulten.reservation.reservation_type"), include_blank: false
     = f.input :telephone, label: t("sulten.reservation.telephone")


### PR DESCRIPTION
Admins have full access to amount of people, table number, date/time etc. Forms are now equal, so they don't induce confusion!