### PR TITLE
new duration options and admin table update

### DIFF
--- a/app/assets/javascripts/sulten/duration.js
+++ b/app/assets/javascripts/sulten/duration.js
@@ -3,7 +3,9 @@
 //Formtastic initialises sulten_reservation_reservation_duration selectoren with :collector
 $("#sulten_reservation_reservation_type_id").change(function(){
 var preValue = parseInt($("#sulten_reservation_reservation_duration").find(":selected").val())
-var durationOptions = [30, 60, 90, 120]
+var durationOptions = null;
+var drinkOptions = [30, 60, 90, 120]
+var foodOptions = [90, 120, 150, 180]
 
   //In prod the values are:
   //mat = 2
@@ -16,7 +18,10 @@ var durationOptions = [30, 60, 90, 120]
   //if testing, change 'this.val()==' to reflect the "Mat/drikke" value in development.
   //remember to change it back to 2 afterwards
   if($(this).val() == 2){
-    durationOptions = durationOptions.slice(2,4)
+    durationOptions = foodOptions;
+  }
+  else {
+    durationOptions = drinkOptions;
   }
 
   $("#sulten_reservation_reservation_duration option").remove()

--- a/app/views/sulten/reservations/admin_new.html.haml
+++ b/app/views/sulten/reservations/admin_new.html.haml
@@ -8,7 +8,7 @@
   <a href="mailto:lyche@samfundet.no">Lyche.</a>
 = semantic_form_for @reservation, url: "/lyche/reservasjon_admin" do |f|
   = f.inputs do
-    = f.input :table_id, label: t("sulten.table.admin_select"), as: :select, collection: Sulten::Table.where(available: true)
+    = f.input :table_id, label: t("sulten.table.admin_select"), as: :select, collection: Sulten::Table.all()
     = f.input :people, label: t("sulten.reservation.people"),as: :number
     = f.input :reservation_from, placeholder: t("sulten.reservation.placeholder_date"), label: t("sulten.reservation.form.from"), input_html: { class: "datetimepicker_lyche"}, as: :string
     = f.input :reservation_duration, label: t("sulten.reservation.form.duration"), collection: [30, 60, 90, 120, 180], member_label: proc{|d| "#{d} minutter"}, include_blank: false, selected: 120

--- a/app/views/sulten/reservations/new.html.haml
+++ b/app/views/sulten/reservations/new.html.haml
@@ -20,7 +20,7 @@
       %p.inline-hints
         = t("sulten.reservation.form.type_explanation")
     = f.input :reservation_type, label: t("sulten.reservation.reservation_type"), include_blank: false
-    = f.input :reservation_duration, label: t("sulten.reservation.form.duration"), collection: [90, 120], member_label: proc{|d| "#{d} minutter"}, include_blank: false
+    = f.input :reservation_duration, label: t("sulten.reservation.form.duration"), collection: [30, 60, 90, 120], member_label: proc{|d| "#{d} minutter"}, include_blank: false, selected: 90
     /collection: [90, 120] because "mat" is selected at load in prod
     = f.input :name, label: t("sulten.reservation.name")
     = f.input :telephone, label: t("sulten.reservation.telephone")


### PR DESCRIPTION
Per request by Line.

Admins can select ANY table now (not only available ones)
Users:
- Drinks: 30, 60, 90, 120 min
- Food: 90, 120, 150, 180 min