### PR TITLE
Parse markdown properly in events

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,7 @@ gem 'route_translator'
 
 # RedCarpet renders Markdown, a light-weight markup language, to HTML.
 # See: config/initializers/haml_markdown.rb
-gem 'redcarpet'
+gem 'redcarpet', '~>3.4'
 
 # route_downcaser adds transparent support for case-insensive routes by downcasing requested URLs.
 gem 'route_downcaser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,7 +318,7 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
-    redcarpet (3.3.4)
+    redcarpet (3.4.0)
     ref (2.0.0)
     route_downcaser (1.2.0)
       activesupport (>= 3.2, < 5.1)
@@ -462,7 +462,7 @@ DEPENDENCIES
   rails (= 5.0.6)
   rails-controller-testing
   rb-fsevent
-  redcarpet
+  redcarpet (~> 3.4)
   route_downcaser
   route_translator
   rspec

--- a/config/initializers/haml_markdown.rb
+++ b/config/initializers/haml_markdown.rb
@@ -13,26 +13,54 @@ class CustomRenderer < Redcarpet::Render::HTML
   end
 end
 
-module Haml::Filters::Markdown
-  include Haml::Filters::Base
 
-  markdown_extensions = {
-    autolink: true,
-    no_intraemphasis: true,
-    superscript: true,
-    fenced_code_blocks: true,
-    tables: true
-  }
+module Haml::Filters
 
-  render_options = {
-    filter_html: true
-  }
+  remove_filter("Markdown") #remove the existing Markdown filter
 
-  markdown = Redcarpet::Markdown.new(CustomRenderer.new(render_options),
-                                     markdown_extensions)
+  module Markdown # the contents of this are as before, but without the lazy_require call
 
-  # using define_method rather than def to keep 'markdown' in scope
-  define_method(:render) do |text|
-    markdown.render(text)
+    include Haml::Filters::Base
+
+    def render(text)
+      markdown.render(text)
+    end
+
+    private
+
+    def markdown
+      @markdown ||= Redcarpet::Markdown.new(renderer, extensions)
+    end
+
+    def renderer
+      @renderer ||= Redcarpet::Render::HTML.new(render_options)
+    end
+
+    def render_options
+      {
+        filter_html: true,
+        hard_wrap: true,
+        no_styles: true,
+        prettify: false,
+        safe_links_only: true,
+        with_toc_data: false
+      }
+    end
+
+    def extensions
+      {
+        autolink: true,
+        footnotes: false,
+        highlight: true,
+        no_intra_emphasis: true,
+        quote: true,
+        space_after_headers: false,
+        strikethrough: true,
+        superscript: true,
+        tables: true,
+        fenced_code_blocks: true
+      }
+    end
   end
+
 end


### PR DESCRIPTION
Rails 5 update broke the markdown support in Events (show). Solution was to update Redcarpet, as well as modifying the render options and extensions.