### PR TITLE
Fix member_roles permission bug

### DIFF
--- a/config/authorization_rules.rb
+++ b/config/authorization_rules.rb
@@ -62,7 +62,7 @@ authorization do
     end
 
     has_permission_on :roles, to: [:read, :manage_members] do
-      if_attribute role_id: is_in { user.roles.select(:id) }
+      if_attribute role_id: is_in { user.roles.pluck(:id) }
     end
 
     has_permission_on :members_roles, to: :manage do


### PR DESCRIPTION
Members were prevented from managing their respective roles because of this broken check
`role_id` is an `integer` and `user.roles.select(:id)` is an array of `Role` objects, so the check would always fail

🍺 