### PR TITLE
Move seperate groups below other jobs

### DIFF
--- a/app/assets/stylesheets/admissions/job_applications.scss
+++ b/app/assets/stylesheets/admissions/job_applications.scss
@@ -54,6 +54,9 @@
 
 .seperate-admission {
     text-align: center;
+    float: left;
+    display: block;
+    width: 100%;
 }
 
 .jobs.show {

--- a/app/assets/stylesheets/admissions/job_applications.scss
+++ b/app/assets/stylesheets/admissions/job_applications.scss
@@ -52,6 +52,10 @@
   }
 }
 
+.seperate-admission {
+    text-align: center;
+}
+
 .jobs.show {
   h2 {
     background-color: $samfundet-light-grey;

--- a/app/views/admissions/_admission.html.haml
+++ b/app/views/admissions/_admission.html.haml
@@ -1,3 +1,9 @@
 != render partial: "groups", locals: { admission: admission }
 
 != render partial: "jobs", locals: { admission: admission }
+
+%div{class:'seperate-admission', id:'seperate_admission'}
+  %h3
+    = t('admissions.groups_with_separate_admission')
+  :markdown
+    #{Admission.first.groups_with_separate_admission}

--- a/app/views/admissions/_groups.html.haml
+++ b/app/views/admissions/_groups.html.haml
@@ -9,4 +9,4 @@
           = group.name
     %br
     %br
-    = t('admissions.seperate_admission_information')
+    %a{href:'#seperate_admission', title:t('admissions.seperate_admission_information')} #{t('admissions.seperate_admission_information')}

--- a/app/views/admissions/_groups.html.haml
+++ b/app/views/admissions/_groups.html.haml
@@ -7,8 +7,6 @@
       %li
         = link_to "##{admission.to_param}/#{group.to_param}" do
           = group.name
-    .separate-admissions
-      %h3
-        = t('admissions.groups_with_separate_admission')
-      :markdown
-        #{Admission.first.groups_with_separate_admission}
+    %br
+    %br
+    = t('admissions.seperate_admission_information')

--- a/app/views/admissions/_groups.html.haml
+++ b/app/views/admissions/_groups.html.haml
@@ -9,4 +9,5 @@
           = group.name
     %br
     %br
-    %a{href:'#seperate_admission', title:t('admissions.seperate_admission_information')} #{t('admissions.seperate_admission_information')}
+    %h3
+      %a{href:'#seperate_admission', title:t('admissions.seperate_admission_information')}  #{t('admissions.seperate_admission_information')}

--- a/app/views/admissions/_jobs.html.haml
+++ b/app/views/admissions/_jobs.html.haml
@@ -15,10 +15,12 @@
               = group_link group, abbreviate_treshold: 20
             .teaser
               #{job.teaser.first(75)}
+
   .seperate-admission
     %h3
       = t('admissions.groups_with_separate_admission')
     :markdown
       #{Admission.first.groups_with_separate_admission}
+      
 #overlay.modal-dialog
   .contentWrap

--- a/app/views/admissions/_jobs.html.haml
+++ b/app/views/admissions/_jobs.html.haml
@@ -15,6 +15,10 @@
               = group_link group, abbreviate_treshold: 20
             .teaser
               #{job.teaser.first(75)}
-
+  .seperate-admission
+    %h3
+      = t('admissions.groups_with_separate_admission')
+    :markdown
+      #{Admission.first.groups_with_separate_admission}
 #overlay.modal-dialog
   .contentWrap

--- a/app/views/admissions/_jobs.html.haml
+++ b/app/views/admissions/_jobs.html.haml
@@ -16,11 +16,5 @@
             .teaser
               #{job.teaser.first(75)}
 
-  .seperate-admission
-    %h3
-      = t('admissions.groups_with_separate_admission')
-    :markdown
-      #{Admission.first.groups_with_separate_admission}
-      
 #overlay.modal-dialog
   .contentWrap

--- a/config/locales/views/admissions/en.yml
+++ b/config/locales/views/admissions/en.yml
@@ -27,8 +27,8 @@ en:
     statistics: "Statistics"
     groups_with_admission: "Groups with admission"
     groups_with_separate_admission: "Groups with separate admission"
-    seperate_admission_information: "Groups with seperate admission can be found at the bottom of the page"
-    
+    seperate_admission_information: "Click here for groups with seperate admission"
+
     admin_applet:
       title: Admissions
 

--- a/config/locales/views/admissions/en.yml
+++ b/config/locales/views/admissions/en.yml
@@ -27,14 +27,15 @@ en:
     statistics: "Statistics"
     groups_with_admission: "Groups with admission"
     groups_with_separate_admission: "Groups with separate admission"
-
+    seperate_admission_information: "Groups with seperate admission can be found at the bottom of the page"
+    
     admin_applet:
       title: Admissions
 
     no_admissions:
         header: "There are currently no admissions to positions at Samfundet"
         ordinary_information: "Samfundet ordinairly has its admissions in the beginning of each semester. Keep an eye on this page!"
-        more_information: "For more information about samfundets groups" 
+        more_information: "For more information about samfundets groups"
         motivation_text: |
           We have our admissions in the beginning of each semester and it would be very much appreciated if you applied as a volunteer!
           Studentersamfundet i Trondhjem is Norways largest student society and we have more to offer than any other city.

--- a/config/locales/views/admissions/no.yml
+++ b/config/locales/views/admissions/no.yml
@@ -27,7 +27,7 @@
     statistics: "Statistikk"
     groups_with_admission: "Gjenger med opptak"
     groups_with_separate_admission: "Gjenger med separat opptak"
-    seperate_admission_information: "Gjenger med seperat opptak ligger nederst på siden"
+    seperate_admission_information: "Klikk her for gjenger med seperat opptak"
 
     admin_applet:
       title: Opptak

--- a/config/locales/views/admissions/no.yml
+++ b/config/locales/views/admissions/no.yml
@@ -27,6 +27,7 @@
     statistics: "Statistikk"
     groups_with_admission: "Gjenger med opptak"
     groups_with_separate_admission: "Gjenger med separat opptak"
+    seperate_admission_information: "Gjenger med seperat opptak ligger nederst på siden"
 
     admin_applet:
       title: Opptak
@@ -34,7 +35,7 @@
     no_admissions:
         header: "Det er for tiden ingen opptak på Samfundet"
         ordinary_information: "Samfundet har sine ordinære opptak på starten av hvert semester. Følg med på denne siden!"
-        more_information: "For mer informasjon om samfundets gjenger" 
+        more_information: "For mer informasjon om samfundets gjenger"
         motivation_text: |
           Vi har opptak på starten av hvert semester og ønsker at du søker til oss som frivillig!
           Studentersamfundet i Trondhjem er Norges største studentersamfund og vi har et tilbud andre byer bare kan drømme om.


### PR DESCRIPTION
We got comments about groups with seperate admission making it hard to find the jobs. They are therefore moved below the jobs