### PR TITLE
Time based notifications

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -1,9 +1,25 @@
 # frozen_string_literal: true
 
 class SiteController < ApplicationController
+  after_action :check_active_notifications
   def index
     @todays_events = Event.today
     @upcoming_events = Event.front_page_events(11)
     @banner_event = @upcoming_events.shift
+  end
+
+  def check_active_notifications
+    register_membership = t('site.notifications.membership.welcome') +
+                     t('site.notifications.membership.click') +
+                     "#{view_context.link_to(t('site.notifications.membership.to_url'), 'https://medlem.samfundet.no')}" +
+                     t('site.notifications.membership.register')
+    flash_in_date_range 8, 9, register_membership
+  end
+
+  def flash_in_date_range(from_month, to_month, message)
+    current_month = Time.now.strftime("%m").to_i
+    if current_month.between?(from_month, to_month)
+      flash[:notice] = message.html_safe
+    end
   end
 end

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -9,17 +9,17 @@ class SiteController < ApplicationController
   end
 
   def check_active_notifications
-    register_membership = t('site.notifications.membership.welcome') +
-                     t('site.notifications.membership.click') +
-                     "#{view_context.link_to(t('site.notifications.membership.to_url'), 'https://medlem.samfundet.no')}" +
-                     t('site.notifications.membership.register')
+    register_membership =
+      t('site.notifications.membership.welcome') +
+      t('site.notifications.membership.click') +
+      view_context.link_to(t('site.notifications.membership.to_url'), 'https://medlem.samfundet.no') +
+      t('site.notifications.membership.register')
     flash_in_date_range 8, 9, register_membership
   end
 
   def flash_in_date_range(from_month, to_month, message)
-    current_month = Time.now.strftime("%m").to_i
-    if current_month.between?(from_month, to_month)
-      flash[:notice] = message.html_safe
-    end
+    current_month = Time.now.strftime('%m').to_i
+    return unless current_month.between?(from_month, to_month)
+    flash[:notice] = view_context.sanitize(message)
   end
 end

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -16,14 +16,15 @@ class SiteController < ApplicationController
     #   %H - Hour of day
     flash_in_date_range = lambda { |date_from, date_to, date_type, msg|
       time_now = Time.now.strftime(date_type).to_i
-      return unless time_now.between?(date_from, date_to)
+      return if not time_now.between?(date_from, date_to)
       flash[:notice] = view_context.sanitize(msg)
     }
 
+    # add all notifications below, call the flashes after each
     register_membership =
-      t('site.notifications.membership.welcome') +
-      t('site.notifications.membership.click') +
-      view_context.link_to(t('site.notifications.membership.to_url'), 'https://medlem.samfundet.no') +
+      t('site.notifications.membership.welcome') + ' ' +
+      t('site.notifications.membership.click') + ' ' +
+      view_context.link_to(t('site.notifications.membership.to_url'), 'https://medlem.samfundet.no') + ' ' +
       t('site.notifications.membership.register')
     flash_in_date_range.call(8, 9, '%m', register_membership)
   end

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -16,7 +16,7 @@ class SiteController < ApplicationController
     #   %H - Hour of day
     flash_in_date_range = lambda { |date_from, date_to, date_type, msg|
       time_now = Time.now.strftime(date_type).to_i
-      return if not time_now.between?(date_from, date_to)
+      return unless time_now.between?(date_from, date_to)
       flash[:notice] = view_context.sanitize(msg)
     }
 

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SiteController < ApplicationController
-  after_action :check_active_notifications
+  before_action :check_active_notifications
   def index
     @todays_events = Event.today
     @upcoming_events = Event.front_page_events(11)
@@ -9,17 +9,22 @@ class SiteController < ApplicationController
   end
 
   def check_active_notifications
+    # from an dto are integers of date_type
+    # some supported (most useful) types:
+    #   %m - Month, e.g. 8 for August, 1 for January
+    #   %d - Day in month
+    #   %H - Hour of day
+    flash_in_date_range = lambda { |date_from, date_to, date_type, msg|
+      time_now = Time.now.strftime(date_type).to_i
+      return unless time_now.between?(date_from, date_to)
+      flash[:notice] = view_context.sanitize(msg)
+    }
+
     register_membership =
       t('site.notifications.membership.welcome') +
       t('site.notifications.membership.click') +
       view_context.link_to(t('site.notifications.membership.to_url'), 'https://medlem.samfundet.no') +
       t('site.notifications.membership.register')
-    flash_in_date_range 8, 9, register_membership
-  end
-
-  def flash_in_date_range(from_month, to_month, message)
-    current_month = Time.now.strftime('%m').to_i
-    return unless current_month.between?(from_month, to_month)
-    flash[:notice] = view_context.sanitize(message)
+    flash_in_date_range.call(8, 9, '%m', register_membership)
   end
 end

--- a/config/locales/views/site/en.yml
+++ b/config/locales/views/site/en.yml
@@ -29,7 +29,7 @@ en:
 
     notifications:
       membership:
-        welcome: "Welcome new members! "
-        click: "Click "
-        to_url: "here "
+        welcome: "Welcome new members!"
+        click: "Click"
+        to_url: "here"
         register: "to register your new card"

--- a/config/locales/views/site/en.yml
+++ b/config/locales/views/site/en.yml
@@ -3,7 +3,7 @@ en:
     title: "Norway's largest student society"
     index:
       og_title: "Student Society in Trondheim"
-      og_description: "Student Society in Trondheim is an organization for students in Trondheim, owned and run by it's 9000 members. The Student Society is Trondheims largest culture organization." 
+      og_description: "Student Society in Trondheim is an organization for students in Trondheim, owned and run by its 9000 members. The Student Society is Trondheims largest culture organization."
 
       add_banner_lock: "Add banner lock"
       change_banner_lock: "Change banner lock"
@@ -30,6 +30,6 @@ en:
     notifications:
       membership:
         welcome: "Welcome new members! "
-        click: "Press "
+        click: "Click "
         to_url: "here "
-        register: "to register your new card :-)"
+        register: "to register your new card"

--- a/config/locales/views/site/en.yml
+++ b/config/locales/views/site/en.yml
@@ -26,3 +26,10 @@ en:
       message_frontpage_highjack: "Placeholder"
       show_more: "Show all events"
       recieve_message: "Receive newsletter"
+
+    notifications:
+      membership:
+        welcome: "Welcome new members! "
+        click: "Press "
+        to_url: "here "
+        register: "to register your new card :-)"

--- a/config/locales/views/site/no.yml
+++ b/config/locales/views/site/no.yml
@@ -32,4 +32,4 @@
         welcome: "Velkommen nye medlemmer! "
         click: "Trykk "
         to_url: "her "
-        register: "for å registrere kortet ditt :-)"
+        register: "for å registrere kortet ditt"

--- a/config/locales/views/site/no.yml
+++ b/config/locales/views/site/no.yml
@@ -29,7 +29,7 @@
 
     notifications:
       membership:
-        welcome: "Velkommen nye medlemmer! "
-        click: "Trykk "
-        to_url: "her "
+        welcome: "Velkommen nye medlemmer!"
+        click: "Trykk"
+        to_url: "her"
         register: "for å registrere kortet ditt"

--- a/config/locales/views/site/no.yml
+++ b/config/locales/views/site/no.yml
@@ -26,3 +26,10 @@
       message_frontpage_highjack: "Placeholder"
       show_more: "Vis alle arrangementer"
       recieve_message: "Motta nyhetsbrev"
+
+    notifications:
+      membership:
+        welcome: "Velkommen nye medlemmer! "
+        click: "Trykk "
+        to_url: "her "
+        register: "for å registrere kortet ditt :-)"


### PR DESCRIPTION
Added due to requests from multiple users to make it easier for new students to register their membership card. In the process, a general implementation was made, which allows us to create notifications based on enumerated months: 1 for january, 8 for august, etc.

This can be used for important updates and the like. Can be further improved to check for given dates, times, etc. Possibly notify members when certain parts of the house are closed. The possibilities are endless!

![image](https://user-images.githubusercontent.com/5024871/44545852-7478e800-a716-11e8-8eed-4887a1d7bfd7.png)
