### PR TITLE
Change scope from job to applicant in job_application

### DIFF
--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -4,7 +4,7 @@ class JobApplication < ApplicationRecord
   belongs_to :applicant
   belongs_to :job
 
-  acts_as_list column: :priority
+  acts_as_list column: :priority, scope: :applicant
 
   has_one :interview, dependent: :destroy
 


### PR DESCRIPTION
After changing to rails 5 it seems the scope was changed from applicant to job. This makes the priority act weirdly, and makes the priority the amount of job_applications in this admission. This pull request patches that problem, and makes the priority be the amount of job_applications of the applicant.