### PR TITLE
Add colorblind mode

### DIFF
--- a/app/assets/javascripts/job_applications/admissions_admin_job_applications.js
+++ b/app/assets/javascripts/job_applications/admissions_admin_job_applications.js
@@ -7,5 +7,6 @@ $(function() {
 $(function() {
   $("#colorblind_mode").click(function (event) {
     $(".job_application_table").toggleClass('colorblind');
+    $(".color_description").toggleClass('display-none')
   });
 });

--- a/app/assets/javascripts/job_applications/admissions_admin_job_applications.js
+++ b/app/assets/javascripts/job_applications/admissions_admin_job_applications.js
@@ -3,3 +3,9 @@ $(function() {
     $(".withdrawn").toggleClass('display-none');
   });
 });
+
+$(function() {
+  $("#colorblind_mode").click(function (event) {
+    $(".job_application_table").toggleClass('colorblind');
+  });
+});

--- a/app/assets/stylesheets/admissions/modules/interviews.scss
+++ b/app/assets/stylesheets/admissions/modules/interviews.scss
@@ -69,14 +69,17 @@
     }
 
     tr.other_job {
-      background-color: #c63a3a;
+      color: #000000 !important;
+      background-color: #d65252;
       a {
         color: #000000 !important;
       }
     }
 
     tr.other_job_reserved {
-      background-color: #e65a5a;
+      color: #000000 !important;
+
+      background-color: #e66a6a;
       a {
         color: #000000 !important;
       }

--- a/app/assets/stylesheets/admissions/modules/interviews.scss
+++ b/app/assets/stylesheets/admissions/modules/interviews.scss
@@ -51,6 +51,41 @@
         display: none !important;
       } } }
 
+  .colorblind{
+    tr.this_job {
+      color: #FFFFFF !important;
+      background-color: #16536A !important;
+      a {
+        color: #FFFFFF !important;
+      }
+    }
+
+    tr.this_job_reserved {
+      color: #FFFFFF !important;
+      background-color: #38758B !important;
+      a {
+        color: #FFFFFF !important;
+      }
+    }
+
+    tr.other_job {
+      background-color: #c63a3a;
+      a {
+        color: #000000 !important;
+      }
+    }
+
+    tr.other_job_reserved {
+      background-color: #e65a5a;
+      a {
+        color: #000000 !important;
+      }
+    }
+
+    tr.withdrawn {
+      background-color: lightgrey;
+    }
+  }
   tr.no_job {
     background-color: #FFF5BC;
   }

--- a/app/views/admissions_admin/jobs/_jobs_show.html.haml
+++ b/app/views/admissions_admin/jobs/_jobs_show.html.haml
@@ -1,7 +1,7 @@
 = javascript_include_tag 'job_applications/admissions_admin_job_applications', defer: true
 .section
   .block
-    %p
+    %p{class:"color_description"}
       %span{ style: "color: #932822"}= t('interviews.red_explanation')
       %br
       %span{ style: "color: #DC706A"}= t('interviews.pink_explanation')
@@ -9,6 +9,19 @@
       %span{ style: "color: #009402"}= t('interviews.green_explanation')
       %br
       %span{ style: "color: #00C703"}= t('interviews.bright_green_explanation')
+      %br
+      %span{ style: "color: #CEC000"}= t('interviews.yellow_explanation')
+      %br
+      %span{ style: "color: grey"}= t('interviews.grey_explanation')
+
+    %p{class:"color_description display-none"}
+      %span{ style: "color: #d65252"}= t('interviews.red_explanation')
+      %br
+      %span{ style: "color: #e66a6a"}= t('interviews.pink_explanation')
+      %br
+      %span{ style: "color: #16536A"}= t('interviews.blue_explanation')
+      %br
+      %span{ style: "color: #38758B"}= t('interviews.bright_blue_explanation')
       %br
       %span{ style: "color: #CEC000"}= t('interviews.yellow_explanation')
       %br

--- a/app/views/admissions_admin/jobs/_jobs_show.html.haml
+++ b/app/views/admissions_admin/jobs/_jobs_show.html.haml
@@ -26,6 +26,7 @@
       %span{ style: "color: #CEC000"}= t('interviews.yellow_explanation')
       %br
       %span{ style: "color: grey"}= t('interviews.grey_explanation')
+      
     %p
       %input#hide_withdrawn{type:"checkbox", checked: true}
         =t('interviews.hide_withdrawn_applications')

--- a/app/views/admissions_admin/jobs/_jobs_show.html.haml
+++ b/app/views/admissions_admin/jobs/_jobs_show.html.haml
@@ -16,6 +16,9 @@
     %p
       %input#hide_withdrawn{type:"checkbox", checked: true}
         =t('interviews.hide_withdrawn_applications')
+      %br
+      %input#colorblind_mode{type:"checkbox", checked: false}
+        =t('interviews.colorblind_mode')
     %table.applications.custom-table.sorted
       %thead
         %th
@@ -42,7 +45,7 @@
         %td
           = t('interviews.interested_other_positions')
 
-      %tbody
+      %tbody{class: "job_application_table"}
         - job_application_groupings.each do |job_applications|
           - job_applications.reverse_each do |job_application|
             %tr{id: "application-#{job_application.id}", class: "#{job_application.assignment_status} #{job_application.withdrawn ? 'display-none' : ''}"}
@@ -93,7 +96,6 @@
                   %span{ class: "status" }
                   = form.actions do
                     != form.action :submit, button_html: { class: "interview_Save", value: 'save'}
-
 
   - if job_application_groupings.empty?
     %p Ingen søknader

--- a/config/locales/views/interviews/en.yml
+++ b/config/locales/views/interviews/en.yml
@@ -19,6 +19,8 @@ en:
     bright_green_explanation: "Bright green: This person is reserved for this job, click the name for more information."
     yellow_explanation: "Yellow: This person will not go to any job, click the name for more information."
     grey_explanation: "Grey: This person has withdrawn their application"
+    blue_explanation: "Blue. This person will go to this job, click the name for more information."
+    bright_blue_explanation: "Bright blue: This person is reserved for this job, click the name for more information."
     applicant_name: "Name"
     applicant_phone_number: "Telephone"
     applicant_email_address: "Email address"

--- a/config/locales/views/interviews/en.yml
+++ b/config/locales/views/interviews/en.yml
@@ -31,4 +31,5 @@ en:
     job: "Job"
     interested_other_positions: "Open for alt. jobs"
     hide_withdrawn_applications: "Hide withdrawn applications"
+    colorblind_mode: "Colorblind mode"
     jobs_applicant_has_applied_to: "Jobs that this applicant has applied to"

--- a/config/locales/views/interviews/no.yml
+++ b/config/locales/views/interviews/no.yml
@@ -31,4 +31,5 @@
     job: "Stilling"
     interested_other_positions: "Ønsker tilbud om andre verv"
     hide_withdrawn_applications: "Skjul trekte søknader"
+    colorblind_mode: "Fargeblind modus"
     jobs_applicant_has_applied_to: "Stillinger denne søkeren har søkt"

--- a/config/locales/views/interviews/no.yml
+++ b/config/locales/views/interviews/no.yml
@@ -19,6 +19,8 @@
     bright_green_explanation: "Lysegrønn: Denne personen er reservert for denne stillingen slik ting er satt nå."
     yellow_explanation: "Gul: Denne personen vil ikke gå til noen stillinger slik ting er satt nå, trykk på navnet for mer info."
     grey_explanation: "Grå: Denne personen har trukket søknaden sin."
+    blue_explanation: "Blå: Denne personen vil gå til denne stillingen slik ting er satt nå."
+    bright_blue_explanation: "Lyseblå: Denne personen er reservert for denne stillingen slik ting er satt nå."
     applicant_name: "Navn"
     applicant_phone_number: "Telefon"
     applicant_email_address: "E-postadresse"


### PR DESCRIPTION
It was near impossible for colorblind people to view the status of applicants. This PR adds a checkbox to change colors into colors that are easier to view