### PR TITLE
Add GET, PUT and DELETE methods to events controller

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -18,6 +18,37 @@ class Api::EventsController < Api::APIController
     end
   end
 
+  def show
+    event = Event.find_by_id(params[:id])
+    if !event.nil?
+      render json: event
+    else
+      render :nothing, status: :not_found
+    end
+  end
+
+  def update
+    event = Event.find_by_id(params[:id])
+    if event.update(event_params)
+      render json: event
+    else
+      render json: event.errors, status: :bad_request
+    end
+  end
+
+  def destroy
+    event = Event.find_by_id(params[:id])
+    if !event.nil?
+      if event.destroy
+        render :nothing, status: :ok
+      else
+        render :nothing, status: :internal_server_error
+      end
+    else
+      render :nothing, status: :bad_request
+    end
+  end
+
   private
 
   def event_params

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -19,7 +19,7 @@ class Api::EventsController < Api::APIController
   end
 
   def show
-    event = Event.find_by_id(params[:id])
+    event = Event.find_by(id: params[:id])
     if !event.nil?
       render json: event
     else
@@ -28,7 +28,7 @@ class Api::EventsController < Api::APIController
   end
 
   def update
-    event = Event.find_by_id(params[:id])
+    event = Event.find_by(id: params[:id])
     if event.update(event_params)
       render json: event
     else
@@ -37,7 +37,7 @@ class Api::EventsController < Api::APIController
   end
 
   def destroy
-    event = Event.find_by_id(params[:id])
+    event = Event.find_by(id: params[:id])
     if !event.nil?
       if event.destroy
         render :nothing, status: :ok

--- a/app/serializers/api/event_serializer.rb
+++ b/app/serializers/api/event_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Api::EventSerializer < ActiveModel::Serializer
-  attributes :id, :short_description
+  attributes *Event.column_names
 end

--- a/app/serializers/api/event_serializer.rb
+++ b/app/serializers/api/event_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Api::EventSerializer < ActiveModel::Serializer
-  attributes *Event.column_names
+  attributes(*Event.column_names)
 end


### PR DESCRIPTION
For record lookups: 
Decided to use `find_by(id: id)` instead of `find_by_id(id)` (being phased out) and `where(id: id).take` (same performance).