### PR TITLE
Add check if member can edit any pages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -113,8 +113,7 @@ class PagesController < ApplicationController
 
   def show_admin?
     can_create = permitted_to?(:new, :pages)
-    can_edit   = permitted_to?(:edit, :pages) # && Page.with_permissions_to(:edit).present?
-    # TODO: Create role for editing group pages
+    can_edit   = permitted_to?(:edit, :pages) && Page.with_permissions_to(:edit).present?
     can_create || can_edit
   end
 


### PR DESCRIPTION
Members without the permission to edit pages can see the admin bar. This pull request fixes that