### PR TITLE
Add pagination for tags

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -6,7 +6,7 @@ class ImagesController < ApplicationController
 
   def index
     @images = Image.paginate(page: params[:page], per_page: 10)
-
+    @tags = Tag.paginate(page: params[:tags], per_page: 40)
     render layout: false if request.xhr?
   end
 

--- a/app/views/images/_search_form.html.haml
+++ b/app/views/images/_search_form.html.haml
@@ -3,9 +3,9 @@
 
 %p
   = t('images.tags')
-
 %ul.tag-list
-  - Tag.by_images_count.each do |tag|
+  - @tags.each do |tag|
     %li
       = link_to search_images_path({ search: tag.name }), data: { tag: tag.name }, class: 'tag' do
         = "#{tag.name} (#{tag.images_count})"
+= will_paginate @tags, :param_name => "tags"


### PR DESCRIPTION
Add pagination for tags. The Tag amount per page is set to 40. This is to prevent all tags to take up the whole image page