### PR TITLE
Fix billig mock service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -173,7 +173,7 @@ group :development do
   gem 'mina', git: 'https://github.com/Samfundet/mina.git'
 
   # A DSL for quickly creating web applications in Ruby with minimal effort.
-  # gem 'sinatra'
+  gem 'sinatra'
 
   # Turns objects into nicely formatted columns for easy reading.
   gem 'table_print'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,6 +249,7 @@ GEM
     minitest (5.11.3)
     multi_json (1.12.1)
     multi_test (0.1.2)
+    mustermann (1.0.3)
     neat (1.8.0)
       sass (>= 3.3)
       thor (~> 0.19)
@@ -281,6 +282,8 @@ GEM
       slop (~> 3.4)
     rack (2.0.5)
     rack-livereload (0.3.16)
+      rack
+    rack-protection (2.0.4)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -370,6 +373,11 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    sinatra (2.0.4)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.4)
+      tilt (~> 2.0)
     slack-notifier (1.5.1)
     slop (3.6.0)
     spring (1.7.2)
@@ -473,6 +481,7 @@ DEPENDENCIES
   sass
   sass-rails
   simplecov
+  sinatra
   slack-notifier
   spring
   spring-watcher-listen (~> 2.0.0)
@@ -487,4 +496,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/lib/billig_service.rb
+++ b/lib/billig_service.rb
@@ -63,12 +63,11 @@ class BilligService < Sinatra::Base
     else
       tickets = []
 
-      params.each do |key, v|
-	value = v.dup
+      params.each do |key, value|
         next unless /price_(\d+)_count/ =~ key
         price_group_id = Regexp.last_match(1)
 
-        value.to_i.times do
+        value.dup.to_i.times do
           ticket_id = (BilligTicket.pluck(:ticket).max || 0) + 1
 
           # This allows for all tickets on membership cards, while in reality,

--- a/lib/billig_service.rb
+++ b/lib/billig_service.rb
@@ -63,7 +63,8 @@ class BilligService < Sinatra::Base
     else
       tickets = []
 
-      params.each do |key, value|
+      params.each do |key, v|
+	value = v.dup
         next unless /price_(\d+)_count/ =~ key
         price_group_id = Regexp.last_match(1)
 
@@ -90,7 +91,7 @@ class BilligService < Sinatra::Base
         end
       end
 
-      redirect 'http://localhost:3000/en/events/purchase_callback/' << tickets.map { |ticket| ticket.ticket.to_s << '12345' }.join(',')
+      redirect 'http://localhost:3000/en/events/purchase_callback/' + tickets.map { |ticket| ticket.ticket.to_s << '12345' }.join(',')
     end
   end
 end


### PR DESCRIPTION
Sinatra gem was commented out, so billig_mock_service would not run.
String literals was made frozen in billig_service.rb when upgrading to rails 5, this made billig_mock_service crash during a ticket purchase. 

Can be tested by running rake billig_mock_service and making a purchase on local environment