### PR TITLE
Remove front-page-hijack [Merge 17. of March 23:59]

### DIFF
--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -32,4 +32,4 @@
       %ul
         %li= link_to t('layouts.application.menu.live'), "https://samfundet.no/live"
         %li= link_to t('layouts.application.menu.membership'), "https://medlem.samfundet.no/"
-        %li= link_to t('layouts.application.menu.admissions'), "https://samfundet.no/arrangement/2087-sok-samfundetstyret"
+        %li= link_to t('layouts.application.menu.admissions'), admissions_path

--- a/app/views/site/_admissions_frontpage_highjack.html.haml
+++ b/app/views/site/_admissions_frontpage_highjack.html.haml
@@ -1,3 +1,3 @@
-= content_for :admissions_frontpage_highjack do
-  = link_to 'https://samfundet.no/arrangement/2087-sok-samfundetstyret', class: 'admissions-frontpage-highjack' do
+-#= content_for :admissions_frontpage_highjack do
+  = link_to 'https://samfundet.no/informasjon/prosessleder', class: 'admissions-frontpage-highjack' do
     = t('site.index.message_frontpage_highjack').html_safe

--- a/config/locales/views/site/en.yml
+++ b/config/locales/views/site/en.yml
@@ -22,7 +22,7 @@ en:
       opening_hours_today: "Opening hours"
 
       admissions_frontpage_highjack: "&lt;!-- Help! Samfundet.no needs developers to fix this error. <u>Apply to MG::Web today!</u> -->"
-      message_frontpage_highjack: "The leader-elect of Samfundet is looking for board members! Application deadline: March 17 at 23:59. Click me for more information!"
+      message_frontpage_highjack: "Placeholder"
       show_more: "Show all events"
       recieve_message: "Receive newsletter"
 

--- a/config/locales/views/site/no.yml
+++ b/config/locales/views/site/no.yml
@@ -23,7 +23,7 @@
       opening_hours_today: "Åpningstider"
 
       admissions_frontpage_highjack: "&lt;!-- Hjelp! Samfundet.no trenger webutviklere for å fikse denne feilen. <u>Søk MG::Web i dag!</u> -->"
-      message_frontpage_highjack: "Samfundets påtroppende leder tar opp nytt Styre! Søknadsfrist 17. mars kl. 23.59. Klikk her for mer informasjon!"
+      message_frontpage_highjack: "Placeholder"
       show_more: "Vis alle arrangementer"
       recieve_message: "Motta nyhetsbrev"
 


### PR DESCRIPTION
This pull request removes the front-page-hijack and uses the right link for OPPTAK. Should not be merged before 17. of March