### PR TITLE
Make CanCanCan find the correct params method

### DIFF
--- a/app/controllers/sulten/closed_periods_controller.rb
+++ b/app/controllers/sulten/closed_periods_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Sulten::ClosedPeriodsController < Sulten::BaseController
-  load_and_authorize_resource
+  load_and_authorize_resource param_method: :sulten_closed_period_params
 
   def index
     @current_and_future_closed_times = Sulten::ClosedPeriod.current_and_future_closed_times


### PR DESCRIPTION
Based on [this](https://stackoverflow.com/questions/17335329/activemodelforbiddenattributeserror-when-creating-new-user) StackOverflow answer, CanCanCan couldn't find the correct params method. Should work properly now.