### PR TITLE
Fix job application bugs

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -130,7 +130,7 @@ class Ability
 
   def mg_nestleder
     # Needs manage permissions here to see statistics
-    can :manage, Admission
+    can :manage, [Admission, JobApplication]
   end
 
   def gjengsjef; end

--- a/app/controllers/job_applications_controller.rb
+++ b/app/controllers/job_applications_controller.rb
@@ -36,7 +36,7 @@ class JobApplicationsController < ApplicationController
   def update
     @job_application = JobApplication.find(params[:id])
 
-    if @job_application.update(job_application_params)
+    if @job_application.update(update_job_application_params)
       @job_application.update_attributes(withdrawn: false)
       flash[:success] = t('job_applications.application_updated')
       if current_user.class == Applicant
@@ -118,5 +118,8 @@ class JobApplicationsController < ApplicationController
 
   def job_application_params
     params.require(:job_application).permit(:job_id, :motivation)
+  end
+  def update_job_application_params
+    params.permit(:job_id, :motiation)
   end
 end

--- a/app/controllers/job_applications_controller.rb
+++ b/app/controllers/job_applications_controller.rb
@@ -119,6 +119,7 @@ class JobApplicationsController < ApplicationController
   def job_application_params
     params.require(:job_application).permit(:job_id, :motivation)
   end
+
   def update_job_application_params
     params.permit(:job_id, :motiation)
   end


### PR DESCRIPTION
This PR fixes two bugs:

1. mg_nestleder can't withdraw job applications. Fixed by giving mg_nestleder manage: [JobApplication] in abilities.rb

2. Nobody could reactivate a job application. Fixed by making :job_application not required when updating job_application