### PR TITLE
Use old front page message

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -25,14 +25,11 @@ class SiteController < ApplicationController
     }
 
     # add all notifications below, call the flashes after each
-    # register_membership =
-    #  t('site.notifications.membership.welcome') + ' ' +
-    #  t('site.notifications.membership.click') + ' ' +
-    #  view_context.link_to(t('site.notifications.membership.to_url'), 'https://medlem.samfundet.no') + ' ' +
-    #  t('site.notifications.membership.register')
-    # flash_in_date_range.call(8, 9, '%m', register_membership)
-
-    building_period = t('site.notifications.membership.building_period1') + ' ' + view_context.link_to(t('site.notifications.membership.uka'), 'https://www.uka.no/') + ' ' + t('site.notifications.membership.building_period2')
-    flash_in_date_range.call(8, 9, '%m', building_period)
+    register_membership =
+      t('site.notifications.membership.welcome') + ' ' +
+      t('site.notifications.membership.click') + ' ' +
+      view_context.link_to(t('site.notifications.membership.to_url'), 'https://medlem.samfundet.no') + ' ' +
+      t('site.notifications.membership.register')
+    flash_in_date_range.call(8, 9, '%m', register_membership)
   end
 end

--- a/config/locales/views/site/en.yml
+++ b/config/locales/views/site/en.yml
@@ -32,6 +32,3 @@ en:
         click: "Click"
         to_url: "here"
         register: "to register your new card"
-        building_period1: "Because of a building period before"
-        building_period2: "the Student Society will be closed."
-        uka: "UKA"

--- a/config/locales/views/site/no.yml
+++ b/config/locales/views/site/no.yml
@@ -33,6 +33,3 @@
         click: "Trykk"
         to_url: "her"
         register: "for å registrere kortet ditt"
-        building_period1: "Grunnet byggeperiode før"
-        building_period2: "er Studentersamfundet stengt."
-        uka: "UKA"


### PR DESCRIPTION
To signal that UKA has a building period at Samfundet, a new message was created to be shown on the front page. Redaksjonen decided to use a closed period instead, which is a better fit, so the front page message is reverted to show the previous message, i.e the welcome message to new members.