### PR TITLE
Add some shortcuts to new Lyche admin reservation

### DIFF
--- a/app/views/sulten/reservations/archive.html.haml
+++ b/app/views/sulten/reservations/archive.html.haml
@@ -1,6 +1,10 @@
 %br
 %h1
   = t("helpers.models.sulten.all", :n => t("helpers.models.sulten.reservation.other"))
+
+%p
+  = link_to t("helpers.models.sulten.new", :n => t("helpers.models.sulten.reservation.one")), sulten_reservasjon_admin_path
+
 %br
 - @reservations.group_by {|i| i.reservation_from.to_date }.each do |date, f|
   %h2

--- a/app/views/sulten/reservations/index.html.haml
+++ b/app/views/sulten/reservations/index.html.haml
@@ -1,6 +1,10 @@
 %br
 %h1
   = "Lyche " + t("sulten.reservation.reservations")
+
+%p
+  = link_to t("helpers.models.sulten.new", :n => t("helpers.models.sulten.reservation.one")), sulten_reservasjon_admin_path
+
 %br
 %h2
   = t("sulten.reservation.summary.title")


### PR DESCRIPTION
From Lyche Hovmester:

> Kom forresten på en ting til som hadde vært fint og hatt. Det er egentlig bare en link/knapp på reservasjonssiden som tar deg til siden for opprettelse av ny reservasjon. Dermed slipper man å gå ut til hovedmenyen hver gang man skal opprette en ny reservasjon. Tenker da denne knappen både på ukesoversikten og på den totale oversikten.