### PR TITLE
Set explicit second-level header font size for mobile and tablet

### DIFF
--- a/app/assets/stylesheets/pages/index.scss
+++ b/app/assets/stylesheets/pages/index.scss
@@ -50,6 +50,12 @@
             }
         }
 
+      h2 {
+        @include media($mobile-and-tablet-portrait) {
+          font-size: 27px;
+        }
+      }
+
         p {
             margin-top: 0;
             margin-bottom: 20px;


### PR DESCRIPTION
There was no explicit second-level header font size for mobile and
tablets. This is the case for the first-level header, and as such the
second-level header would be bigger than the first-level header on
mobile and tablet. This also potentially fixes some cases where a long
second-level header would make it possible to scroll horizontally as the
text would bleed out across the horizontal edge.