### PR TITLE
Give MG-Redaksjonen access to images

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -111,7 +111,7 @@ class Ability
   end
 
   def mg_redaksjon
-    can :manage, [Blog, Event, Page, FrontPageLock, EverythingClosedPeriod, Area]
+    can :manage, [Blog, Event, Page, FrontPageLock, EverythingClosedPeriod, Area, Image]
   end
 
   # ORGANIZATION

--- a/app/views/images/_imagepicker.html.haml
+++ b/app/views/images/_imagepicker.html.haml
@@ -3,8 +3,8 @@
   = image_tag Image.image_for(f.object).image_file.url, class: 'image-preview'
 
   %ul
-    %li= link_to t('events.forms.existing_image'), images_path, class: 'choose-image-link'
     - if can? :create, Image
+      %li= link_to t('events.forms.existing_image'), images_path, class: 'choose-image-link'
       %li= link_to t('events.forms.upload_image'), new_image_path, target: 'blank'
     - else
-      %li Du må kontakte layout i markedsføringsgjengen for å få lagt til nye bilder i systemet.
+      %li= t('events.forms.contact_layout_or_redaksjonen')

--- a/config/locales/views/events/en.yml
+++ b/config/locales/views/events/en.yml
@@ -192,6 +192,7 @@ en:
 
         existing_image: Select existing image
         upload_image: Upload new image
+        contact_layout_or_redaksjonen: You must contact Layout or Redaksjonen in Markedsføringsgjengen to add new images to the system.
 
     search:
         title: Search for events

--- a/config/locales/views/events/no.yml
+++ b/config/locales/views/events/no.yml
@@ -196,6 +196,7 @@
 
         existing_image: Velg eksisterende bilde
         upload_image: Last opp nytt bilde
+        contact_layout_or_redaksjonen: Du må kontakte Layout eller Redaksjonen i Markedsføringsgjengen for å få lagt til nye bilder i systemet.
 
 
     search:


### PR DESCRIPTION
As of before this commit MG-Redaksjonen didn't have access to
images. They didn't have access to images from the control panel,
but when creating events (which they can), there was a link to adding an
existing image to the event which wasn't guarded behing an ability check
(like `-if can? :create, Image`), which meant lots of permission denied
errors. The 'upload new image' button was behind such a guard, so they
would never see it. This commit gives the MG-Redaksjonen ability to see,
add existing images to events and upload new images. It also hides the
use existing image button from the events creation form for people that
shouldn't see it. Lastly it translates the messages seen in the events
from when you don't have permissions to see images.