### PR TITLE
Fix confirmation boxes not appearing

### DIFF
--- a/app/views/admissions_admin/groups/show.html.haml
+++ b/app/views/admissions_admin/groups/show.html.haml
@@ -47,7 +47,7 @@
           - if @should_show_delete_button
             %td
               - if can?(:destroy, Job, job) && !job.job_applications.exists?
-                != link_to t('groups.delete_job'), admissions_admin_admission_group_job_path(@admission, @group, job), method: "delete", confirm: t('crud.confirm')
+                != link_to t('groups.delete_job'), admissions_admin_admission_group_job_path(@admission, @group, job), method: "delete", data: { confirm: t('crud.confirm') }
 
   - if can?(:create, Job)
     %p

--- a/app/views/admissions_admin/job_applications/show.html.haml
+++ b/app/views/admissions_admin/job_applications/show.html.haml
@@ -30,9 +30,9 @@
 
     - if can?(:withdraw, JobApplication)
       - if !@job_application.withdrawn
-        %h3= link_to 'Trekk søknad', job_application_path(@job_application), method: :delete, confirm: "Er du sikker?"
+        %h3= link_to 'Trekk søknad', job_application_path(@job_application), method: :delete, data: { confirm: "Er du sikker?" }
       - else
-        %h3= link_to 'Aktiver søknad', job_application_path(@job_application), method: :put, confirm: "Er du sikker?"
+        %h3= link_to 'Aktiver søknad', job_application_path(@job_application), method: :put, data: { confirm: "Er du sikker?" }
 
   .log
     %h3= t('job_applications.log_entries.log_entries')
@@ -62,7 +62,7 @@
             = log_entry.member.full_name
           %td
             = link_to t('crud.destroy').humanize, [:admissions_admin, @job_application.job.admission,
-            @job_application.job.group, @job_application.applicant, log_entry], method: "delete", confirm: t('crud.confirm')
+            @job_application.job.group, @job_application.applicant, log_entry], method: "delete", data: { confirm: t('crud.confirm') }
 
   .soknader
     %h3= t('job_applications.applications')

--- a/app/views/blogs/admin.html.haml
+++ b/app/views/blogs/admin.html.haml
@@ -32,4 +32,4 @@
           = link_to t("crud.edit"), edit_blog_path(article)
         %td
           - if can? :destroy, article
-            = link_to t("crud.destroy"), article, confirm: t("events.confirm_delete"), method: :delete
+            = link_to t("crud.destroy"), article, data: { confirm: t("crud.confirm") }, method: :delete

--- a/app/views/blogs/show.html.haml
+++ b/app/views/blogs/show.html.haml
@@ -15,7 +15,7 @@
         %li
           = link_to t("crud.edit"), edit_blog_path(@article)
         %li
-          = link_to t("crud.destroy"), @article, confirm: t("crud.destroy"), method: :delete
+          = link_to t("crud.destroy"), @article, data: { confirm: t("crud.destroy") }, method: :delete
         %li
           = link_to t("blog.admin"), admin_blogs_path
 

--- a/app/views/documents/admin.html.haml
+++ b/app/views/documents/admin.html.haml
@@ -29,4 +29,4 @@
                 = link_to t('crud.edit'), edit_document_path(document)
             %td
               - if can? :destroy, document
-                = link_to t('crud.destroy'), document, confirm: t('documents.confirm_delete'), method: :delete
+                = link_to t('crud.destroy'), document, data: { confirm: t('documents.confirm_delete') }, method: :delete

--- a/app/views/events/_admin_choices.html.haml
+++ b/app/views/events/_admin_choices.html.haml
@@ -8,7 +8,7 @@
         = link_to t("crud.edit"), edit_event_path(@event)
 
       %li
-        = link_to t("crud.destroy"), @page, confirm: t("events.confirm_delete"), method: :delete
+        = link_to t("crud.destroy"), @page, data: { confirm: t("events.confirm_delete") }, method: :delete
 
       %li
         = link_to t("event.admin"), admin_events_path

--- a/app/views/events/_admin_list.html.haml
+++ b/app/views/events/_admin_list.html.haml
@@ -29,4 +29,4 @@
           %td= link_to t("crud.edit"), edit_event_path(event)
 
         - if can? :destroy, event
-          %td= link_to t("crud.destroy"), event, confirm: t("events.confirm_delete"), method: :delete
+          %td= link_to t("crud.destroy"), event, data: { confirm: t("events.confirm_delete") }, method: :delete

--- a/app/views/everything_closed_periods/index.html.haml
+++ b/app/views/everything_closed_periods/index.html.haml
@@ -23,7 +23,7 @@
       %td= ecp.closed_from.to_date
       %td= ecp.closed_to.to_date
       %td= link_to t('crud.edit'), edit_everything_closed_period_path(ecp.id)
-      %td= link_to t('crud.destroy'), everything_closed_period_path(ecp.id), confirm: t('crud.confirm'), method: :delete
+      %td= link_to t('crud.destroy'), everything_closed_period_path(ecp.id), data: { confirm: t('crud.confirm') }, method: :delete
   %tfoot
     %tr
       %td{colspan: 5}= link_to t('everything_closed_periods.add_new_link'), new_everything_closed_period_path

--- a/app/views/images/show.html.haml
+++ b/app/views/images/show.html.haml
@@ -11,7 +11,7 @@
   - if can? :edit, @image
     = link_to t('crud.edit'), edit_image_path
   - if can? :destroy || @image.uploader == @current_user, @image
-    = link_to t('crud.destroy'), @image, confirm: t('crud.confirm'), method: :delete
+    = link_to t('crud.destroy'), @image, data: { confirm: t('crud.confirm') }, method: :delete
 
 %h2= t('images.tags')
 - if @image.tags.any?

--- a/app/views/job_applications/_form.html.haml
+++ b/app/views/job_applications/_form.html.haml
@@ -22,5 +22,5 @@
 
 
 - if @already_applied and !@job_application.withdrawn
-  = link_to @job_application, { method: :delete, style:"position:relative; top:-53px; left:180px", class: "sexybutton sexysimple sexyred", id: "delete_job_application", confirm: t('crud.confirm') } do
+  = link_to @job_application, { method: :delete, style:"position:relative; top:-53px; left:180px", class: "sexybutton sexysimple sexyred", id: "delete_job_application", data: { confirm: t('crud.confirm') } } do
     = t('job_applications.forms.edit.withdraw')

--- a/app/views/pages/_admin_choices.html.haml
+++ b/app/views/pages/_admin_choices.html.haml
@@ -11,7 +11,7 @@
 
       - if can? :destroy, @page
         %li
-          = link_to t("crud.destroy"), @page, confirm: t("pages.confirm_delete"), method: :delete
+          = link_to t("crud.destroy"), @page, data: { confirm: t("pages.confirm_delete") }, method: :delete
 
       %li
         = link_to t("pages.admin"), admin_pages_path

--- a/app/views/pages/admin.html.haml
+++ b/app/views/pages/admin.html.haml
@@ -27,4 +27,4 @@
           %td= link_to t("crud.edit"), edit_page_path(page)
           %td
             - if can? :destroy, page
-              = link_to t("crud.destroy"), page, confirm: t("pages.confirm_delete"), method: :delete
+              = link_to t("crud.destroy"), page, data: { confirm: t("pages.confirm_delete") }, method: :delete

--- a/app/views/roles/one_year_old.html.haml
+++ b/app/views/roles/one_year_old.html.haml
@@ -25,4 +25,4 @@
         = link_to t('roles.remove_member'),
                   [members_role.role, members_role],
                   method: :delete,
-                  confirm: t('crud.confirm')
+                  data: { confirm: t('crud.confirm') }

--- a/app/views/roles/show.html.haml
+++ b/app/views/roles/show.html.haml
@@ -43,7 +43,7 @@
             = link_to t('roles.remove_member'),
                       [@role, members_role],
                       method: :delete,
-                      confirm: t('crud.confirm')
+                      data: { confirm: t('crud.confirm') }
   %h2= t('roles.add_member')
   = form_tag role_members_roles_path(@role), method: :post do
     %p

--- a/app/views/sulten/closed_periods/index.html.haml
+++ b/app/views/sulten/closed_periods/index.html.haml
@@ -18,7 +18,7 @@
       %td= ecp.closed_from.to_date
       %td= ecp.closed_to.to_date
       %td= link_to t('crud.edit'), edit_sulten_closed_period_path(ecp.id)
-      %td= link_to t('crud.destroy'), sulten_closed_period_path(ecp.id), confirm: t('crud.confirm'), method: :delete
+      %td= link_to t('crud.destroy'), sulten_closed_period_path(ecp.id), data: { confirm: t('crud.confirm') }, method: :delete
   %tfoot
     %tr
       %td{colspan: 5}= link_to t('sulten.closed_periods.add_new_link'), new_sulten_closed_period_path

--- a/app/views/sulten/reservation_types/index.html.haml
+++ b/app/views/sulten/reservation_types/index.html.haml
@@ -16,6 +16,6 @@
       %td
         = link_to t("crud.edit"), edit_sulten_reservation_type_path(t)
       %td
-        = link_to t("crud.destroy"), t, confirm: t("crud.confirm"), method: :delete
+        = link_to t("crud.destroy"), t, data: { confirm: t("crud.confirm") }, method: :delete
 %p
   = link_to t("common.back"), sulten_admin_path

--- a/app/views/sulten/tables/index.html.haml
+++ b/app/views/sulten/tables/index.html.haml
@@ -40,6 +40,6 @@
       %td
         = link_to t("crud.edit"), edit_sulten_table_path(t)
       %td
-        = link_to t("crud.destroy"), t, confirm: t("crud.confirm"), method: :delete
+        = link_to t("crud.destroy"), t, data: { confirm: t("crud.confirm") }, method: :delete
 %p
   = link_to t("common.back"), sulten_admin_path


### PR DESCRIPTION
I previously thought there were _no_ confirmation boxes on anything, but
it turns out that confirmation boxes on delete requests were covered
pretty good. Probably the old syntax was deprecated and no longer
triggering like it used to. You should now get a confirmation box
whenever trying to delete something (which we should have).