### PR TITLE
Fix change password

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -77,7 +77,7 @@ class ApplicantsController < ApplicationController
       flash[:error] = t('applicants.password_recovery.email_unknown')
     elsif !@applicant.can_recover_password?
       flash[:error] = t('applicants.password_recovery.limit_reached')
-    elsif PasswordRecovery.create!(id: @applicant.id,
+    elsif PasswordRecovery.create!(applicant_id: @applicant.id,
                                    recovery_hash: @applicant.create_recovery_hash)
       begin
         ForgotPasswordMailer.forgot_password_email(@applicant).deliver
@@ -109,7 +109,7 @@ class ApplicantsController < ApplicationController
     if @applicant.check_hash(params[:hash])
       if @applicant.update_attributes(password: new_data[:password],
                                       password_confirmation: new_data[:password_confirmation])
-        PasswordRecovery.destroy(params[:id])
+        PasswordRecovery.find_by(applicant_id: @applicant.id).destroy
         flash[:success] = t('applicants.password_recovery.change_success')
 
         redirect_to login_path

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -93,13 +93,18 @@ class ApplicantsController < ApplicationController
     redirect_to forgot_password_path
   end
 
+  def prepare_form
+    @hash = params[:hash]
+    @email = params[:email]
+  end
+
   def reset_password
     @applicant = Applicant.find_by(email: params[:email])
     if !@applicant || !@applicant.check_hash(params[:hash])
       flash[:error] = t('applicants.password_recovery.hash_error')
       @applicant = nil
     else
-      @hash = params[:hash]
+      prepare_form
     end
   end
 
@@ -114,10 +119,12 @@ class ApplicantsController < ApplicationController
 
         redirect_to login_path
       else
+        prepare_form
         flash[:error] = t('applicants.password_recovery.change_error')
         render :reset_password
       end
     else
+      prepare_form
       flash[:error] = t('applicants.password_recovery.change_error')
       render :reset_password
     end

--- a/app/views/applicants/_form_reset_password.html.haml
+++ b/app/views/applicants/_form_reset_password.html.haml
@@ -4,7 +4,8 @@
 
   != hidden_field_tag "next", @next if @next
   != hidden_field_tag "hash", hash
-  
+  != hidden_field_tag "email", email
+
   = form.inputs do
     != form.input :password, input_html: { value: "" }
     != form.input :password_confirmation, input_html: { value: "" }

--- a/app/views/applicants/reset_password.html.haml
+++ b/app/views/applicants/reset_password.html.haml
@@ -2,4 +2,4 @@
 
 .section
   - if @applicant
-    = render 'form_reset_password', applicant: @applicant, hash: @hash
+    = render 'form_reset_password', applicant: @applicant, hash: @hash, email: @email

--- a/config/locales/activerecord_en.yml
+++ b/config/locales/activerecord_en.yml
@@ -1,6 +1,13 @@
 en:
   activerecord:
       errors:
+        models:
+          applicant:
+            attributes:
+              password:
+                too_short: "The password is too short, must be at least %{count} characters."
+              password_confirmation:
+                confirmation: "Password confirmation does not match."
         template:
           header: "Could not save %{model} beause %{count} is wrong."
           body: "problems arose because of the following fields:"

--- a/config/locales/activerecord_no.yml
+++ b/config/locales/activerecord_no.yml
@@ -2,6 +2,12 @@
   activerecord:
       errors:
         models:
+          applicant:
+            attributes:
+              password:
+                too_short: "Passordet er for kort, må være minst %{count} tegn"
+              password_confirmation:
+                confirmation: "Bekreftelsen er ikke den samme"
           event:
             attributes:
               start_time:


### PR DESCRIPTION
Second attempt at fixing the reset password feature. Tries to find a `PasswordRecovery` object before deleting it from the database. Also rolls back to using the `applicant_id` parameter and the `@applicant` object.

Need multiple people to test this so we know it works.