### PR TITLE
Fix bug in applicant priority

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'dalli', '~> 2.7.0'
 # acts_as_list provides the means to sort and reorder a list of objects
 # with respect to a column in the database, e.g. to sort and reorder a list
 # of job applications based on the priority set by the applicant.
-gem 'acts_as_list', '~> 0.8.0'
+gem 'acts_as_list', '~> 1.0.0'
 
 # Use activerecord as session store
 gem 'activerecord-session_store', '~> 1.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,8 +62,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    acts_as_list (0.8.2)
-      activerecord (>= 3.0)
+    acts_as_list (1.0.0)
+      activerecord (>= 4.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     annotate (2.7.5)
@@ -417,7 +417,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-session_store (~> 1.1.0)
-  acts_as_list (~> 0.8.0)
+  acts_as_list (~> 1.0.0)
   annotate (~> 2.7.0)
   bcrypt (~> 3.1.0)
   better_errors (~> 2.1.0)


### PR DESCRIPTION
The old version of acts_as_list didn't correctly set the priorities of the applicants. This led to a bug where applicants could have two or more job applications with the same priority. 