### PR TITLE
Fixes error rendering calendar on sundays

### DIFF
--- a/app/controllers/sulten/reservations_controller.rb
+++ b/app/controllers/sulten/reservations_controller.rb
@@ -104,6 +104,9 @@ class Sulten::ReservationsController < Sulten::BaseController
     @reservations.each do |res|
       @render_reservations[res.table_id] = []
     end
+    @reservations_today.each do |res|
+      @render_reservations[res.table_id] = []
+    end
 
     @reservations_today.each do |res|
       offset_percent = ((res.reservation_from - start_timeline).seconds / length_timeline).to_f * 100


### PR DESCRIPTION
- Fixes error caused by a reservation on a Sunday around midnight extended into next week, and was therefore missing from weekly list