### PR TITLE
[WIP] Upgrade to Mina v1.2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -176,7 +176,7 @@ group :development do
   gem 'rb-fsevent', '~> 0.10.3', require: false
 
   # Simple command execution over SSH. Lightweight deployment tool.
-  gem 'mina', '~> 0.3.0'
+  gem 'mina', '~> 1.2.0'
 
   # A DSL for quickly creating web applications in Ruby with minimal effort.
   gem 'sinatra', '~> 2.0.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,7 +225,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
     mimemagic (0.3.4)
-    mina (0.3.8)
+    mina (1.2.3)
       open4 (~> 1.3.4)
       rake
     mini_mime (1.0.2)
@@ -455,7 +455,7 @@ DEPENDENCIES
   letter_opener (~> 1.7.0)
   listen (~> 3.2.1)
   magic_encoding (~> 0.0.0)
-  mina (~> 0.3.0)
+  mina (~> 1.2.0)
   neat (~> 1.8.0)
   paperclip (~> 5.2.0)
   paperclip-compression (~> 1.0.0)


### PR DESCRIPTION
Mina seems to actually work on v1.2.3 as I was just able to correctly deploy a new version of www-beta. Should probably be vetted some more on www-beta, just to be sure that we don't fuck anything up. Also, production is no configured yet, must run `RAILS_ENV=production bundle exec mina setup` to make that happen.

Mina has its own [migration guide](https://github.com/mina-deploy/mina/blob/master/docs/migrating.md) that I followed.