### PR TITLE
Do not compare interview times if we just removed it

### DIFF
--- a/app/controllers/admissions_admin/interviews_controller.rb
+++ b/app/controllers/admissions_admin/interviews_controller.rb
@@ -73,6 +73,12 @@ class AdmissionsAdmin::InterviewsController < AdmissionsAdmin::BaseController
 private
 
   def show_warning_if_other_interviews_take_place_within_30_minutes
+    # If we just removed the time for the inteview, it will be nil and
+    # it won't make sense to compare its time to the time of other job applications.
+    # In fact, removing this early return will spew out horrible error messages
+    # in the interview table.
+    return if @interview.time.nil?
+
     @interview.job_application.applicant.job_applications.each do |application|
       next if (application == @interview.job_application) || application.interview.nil? || application.interview.time.nil?
 


### PR DESCRIPTION
This commit fixes a bug that would spew out horrible error messages
in the interview table if the interview time was removed for some
reason. If we remove the time of the interview, we do not care
about other interviews, so we just return early.

Fixes #564