### PR TITLE
Extract possible log entries to static method

### DIFF
--- a/app/controllers/admissions_admin/job_applications_controller.rb
+++ b/app/controllers/admissions_admin/job_applications_controller.rb
@@ -10,27 +10,7 @@ class AdmissionsAdmin::JobApplicationsController < AdmissionsAdmin::BaseControll
       admission_id: @job_application.job.admission.id,
       group_id: @job_application.job.group.id
     )
-    if I18n.locale == :no
-      @possible_log_entries = [
-        'Forsøkt ringt, tok ikke telefonen',
-        'Ringt og tilbudt verv, venter på svar',
-        'Ringt, venter fremdeles på svar',
-        'Ringt og tilbudt verv, takket ja',
-        'Ringt og tilbudt verv, takket nei',
-        'Ringt og meddelt ingen tilbud om verv',
-        'Sendt e-post og meddelt ingen tilbud om verv'
-      ]
-    elsif I18n.locale == :en
-      @possible_log_entries = [
-        'Called, no reply',
-        'Called and offered position, awaiting reply',
-        'Called, still waiting for reply',
-        'Called and offered position, the applicant accepted',
-        'Called and offered position, the applicant declined',
-        'Called and notified the applicant of our rejection',
-        'Sent email and notified the applicant of our rejection'
-      ]
-    end
+    @possible_log_entries = LogEntry.possible_log_entries
   end
 
   def hidden_create

--- a/app/models/log_entry.rb
+++ b/app/models/log_entry.rb
@@ -9,6 +9,18 @@ class LogEntry < ApplicationRecord
   belongs_to :member
 
   default_scope { order(created_at: :asc) }
+
+  def self.possible_log_entries
+    [
+      I18n.t('activerecord.models.possible_log_entries.called_no_answer'),
+      I18n.t('activerecord.models.possible_log_entries.called_offered_job_waiting'),
+      I18n.t('activerecord.models.possible_log_entries.called_still_waiting'),
+      I18n.t('activerecord.models.possible_log_entries.called_offered_job_accepted'),
+      I18n.t('activerecord.models.possible_log_entries.called_offered_job_declined'),
+      I18n.t('activerecord.models.possible_log_entries.called_no_offer'),
+      I18n.t('activerecord.models.possible_log_entries.emailed_no_offer')
+    ]
+  end
 end
 
 # == Schema Information

--- a/config/locales/models/log_entry/en.yml
+++ b/config/locales/models/log_entry/en.yml
@@ -4,6 +4,14 @@ en:
       log_entry:
         one: "log entry"
         other: "log entries"
+      possible_log_entries:
+        called_no_answer: 'Called, no reply'
+        called_offered_job_waiting: 'Called and offered position, awaiting reply'
+        called_still_waiting: 'Called, still waiting for reply'
+        called_offered_job_accepted: 'Called and offered position, the applicant accepted'
+        called_offered_job_declined: 'Called and offered position, the applicant declined'
+        called_no_offer: 'Called and notified the applicant of our rejection'
+        emailed_no_offer: 'Sent email and notified the applicant of our rejection'
     attributes:
       log_entry:
         log: Log

--- a/config/locales/models/log_entry/no.yml
+++ b/config/locales/models/log_entry/no.yml
@@ -4,6 +4,14 @@
       log_entry:
         one: "loggføring"
         other: "loggføringer"
+      possible_log_entries:
+        called_no_answer: 'Forsøkt ringt, tok ikke telefonen'
+        called_offered_job_waiting: 'Ringt og tilbudt verv, venter på svar'
+        called_still_waiting: 'Ringt, venter fremdeles på svar'
+        called_offered_job_accepted: 'Ringt og tilbudt verv, takket ja'
+        called_offered_job_declined: 'Ringt og tilbudt verv, takket nei'
+        called_no_offer: 'Ringt og meddelt ingen tilbud om verv'
+        emailed_no_offer: 'Sendt e-post og meddelt ingen tilbud om verv'
     attributes:
       log_entry:
         log: Logg


### PR DESCRIPTION
This method was accidentally removed in a previous clean-up PR,
which broke the seed script. Anyway, it's better to collect such
functionality inside the model instead of scattered around in
different controllers.