### PR TITLE
Log applicants directly in interview table

### DIFF
--- a/app/helpers/admission_groups_helper.rb
+++ b/app/helpers/admission_groups_helper.rb
@@ -10,4 +10,13 @@ module AdmissionGroupsHelper
       admissions_admin_admission_group_path(admission, group)
     end
   end
+
+  # This method is used primarily in the interview table for showing the last n
+  # log entries for an applicant.
+  def interview_log_entries_list_text(admission, applicant, l)
+    log_entries = applicant.log_entries_in_admission(admission)
+    index = log_entries.index(l) + 1
+
+    "Log \##{index}: #{l.log} (#{l.group.short_name})"
+  end
 end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -116,6 +116,18 @@ class Applicant < ApplicationRecord
     group.job_applications_in_admission(admission).select { |ja| ja.applicant == self }
   end
 
+  def log_entries_in_admission(admission, group: nil)
+    unless group.nil?
+      log_entries.select do |l|
+        l.admission_id == admission.id and l.group_id == group.id
+      end
+    end
+
+    log_entries.select do |l|
+      l.admission.id == admission.id
+    end
+  end
+
 private
 
   def lowercase_email

--- a/app/views/admissions_admin/jobs/_jobs_show.html.haml
+++ b/app/views/admissions_admin/jobs/_jobs_show.html.haml
@@ -100,9 +100,24 @@
                   = form.actions do
                     != form.action :submit, button_html: { class: "interview_save", value: 'save' }
               %td
-                - if job_application.last_log_entry
+                = semantic_form_for(job_application.applicant, namespace: "interview_#{interview.id}", html: {class: "test custom-form interview"}) do |form|
+                  = hidden_field_tag 'admission_id', @admission.id
+                  = hidden_field_tag 'group_id', @group.id
+                  %strong='Create new log entry'
+                  = form.select(:log_entries, 'Possible log entries': LogEntry.possible_log_entries)
+                  %span{ class: "status" }
+                  = form.actions do
+                    != form.action :submit, button_html: { class: "interview_Save", value: 'save'}
+                %br
+                - unless job_application.applicant.log_entries.where(admission_id: @admission.id).empty?
+                  %strong='Last log entries'
+                  %br
                   = link_to admissions_admin_admission_group_job_job_application_path(@admission, @group, job_application.job, job_application, anchor: 'new_log_entry') do
-                    = job_application.last_log_entry.log
+                    - job_application.applicant.log_entries_in_admission(@admission).last(3).reverse.each do |l|
+                      = interview_log_entries_list_text(@admission, job_application.applicant, l)
+                      %br
+                - else
+                  %em= "Applicant has not been logged yet"
               %td
                 = semantic_form_for(job_application.applicant, namespace: "interview_#{interview.id}", html: {class: "test custom-form interview"}) do |form|
                   = form.inputs do


### PR DESCRIPTION
Fixes #577 

**Commit message**:

I am not convinced that this is the best way to solve this.
It's not a critical improvement, but a nice-to-have improvement.

**Other information**:

This would give us a total of three locations where we could log applicants:

- When viewing a specific job application (as we have always been able to)
- When showing all interviews for a single job in a group
- When showing all interviews for all jobs in a group

Other ideas:

- We could also add information about which group last added a log entry. I'm a bit worried this could lead to each rowing becoming a bit too tall, making long tables _even_ longer.

**v1**:

![image](https://user-images.githubusercontent.com/6376002/77474870-25c29100-6e18-11ea-80c1-f8fe650ebe81.png)

**v2**:

![image2](https://user-images.githubusercontent.com/6376002/77693121-1eca8880-6fa8-11ea-9435-1abb7d0f116b.png)

**TODO**:

- [ ] Number log entries as `Log #x` instead of `x.`, as in `Log #3` to signal that it's the third log entry.