### PR TITLE
Upgrade paperclip-compression

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,7 +107,7 @@ gem 'will_paginate', '~> 3.1.0'
 gem 'paperclip', '~> 5.2.0'
 
 # automatic compression of images uploaded via paperclip
-gem 'paperclip-compression', '~> 1.0.0'
+gem 'paperclip-compression', '~> 1.1.0'
 
 # A simple date validator for Rails 3.
 gem 'date_validator', '~> 0.9.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,7 @@ GEM
       cocaine (~> 0.5.5)
       mime-types
       mimemagic (~> 0.3.0)
-    paperclip-compression (1.0.2)
+    paperclip-compression (1.1.1)
       os (~> 1.0.0)
       paperclip (>= 5.2.1)
     parallel (1.19.1)
@@ -456,7 +456,7 @@ DEPENDENCIES
   mina (~> 0.3.0)
   neat (~> 1.8.0)
   paperclip (~> 5.2.0)
-  paperclip-compression (~> 1.0.0)
+  paperclip-compression (~> 1.1.0)
   pg (~> 1.1.0)
   pg_search (~> 2.3.0)
   rack-livereload (~> 0.3.17)


### PR DESCRIPTION
This should be a totally painless upgrade. We're upgrading from 1.0.2 to 1.1.1 (via 1.1.0) and the versions since 1.0.2 have been about

- 1.1.1: Updated a development dependency
- 1.1.0: macOS Catalina support (which fixes the seed script, see more below)

**About the seed script**

Version 1.1.0 of paperclip-compression fixes macOS Catalina support (i.e. the error that occurred during seeding is no longer present), but you _must_ rebuild the Ruby version if you installed the Ruby version on macOS Mojave and upgraded to macOS Catalina and haven't reinstalled the Ruby version since.