### PR TITLE
Validate publication time on event create

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -28,7 +28,7 @@ class Event < ApplicationRecord
   localized_fields :title, :short_description, :long_description
 
   validates :title_en, :non_billig_title_no, :short_description_en, :short_description_no, :non_billig_start_time, :age_limit,
-            :event_type, :status, :area, :organizer, :price_type, :banner_alignment, :image_id, presence: true
+            :event_type, :status, :area, :organizer, :price_type, :banner_alignment, :image_id, :publication_time, presence: true
   validates :age_limit, inclusion: { in: AGE_LIMIT, message: 'Invalid age limit' }
   validates :event_type, inclusion: { in: EVENT_TYPE, message: 'Invalid type' }
   validates :status, inclusion: { in: STATUS, message: 'Invalid status' }

--- a/spec/factories/event_factory.rb
+++ b/spec/factories/event_factory.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :event do
+    title_en { Faker::Lorem.sentence }
+    non_billig_title_no { Faker::Lorem.sentence }
+    short_description_en { Faker::Lorem.sentences }
+    short_description_no { Faker::Lorem.sentences }
+    event_type { :music }
+    age_limit { :eighteen }
+    area { Area.create(name: 'NBB', description: 'Best place on Earth') }
+    price_type { 'free' }
+    status { :active }
+    primary_color { '#fff' }
+    secondary_color { '#fff' }
+    banner_alignment { 'hide' }
+    non_billig_start_time { 2.days.from_now }
+    publication_time { Time.now }
+    organizer { ExternalOrganizer.create!(name: 'NTNU') }
+    image { Image.default_image }
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'rails_helper'
+
+describe Event do
+  it 'should throw exception when created without a publication time' do
+    expect do
+      create(:event, publication_time: nil)
+    end.to raise_error(ActiveRecord::RecordInvalid)
+  end
+end


### PR DESCRIPTION
Fixes #655 

We were not validating publication time when creating new events.
This would result in an ugly error message concerning a PostgreSQL
NotNullViolation immediately after submitting. This is because the
PostgreSQL Search gem (pg_search) creates its own table of which a
column is "publish_at" (which is declared `null: false`). This
"publish_at" column would then interact with the publication_time
column, which would result in a crash.