### PR TITLE
Don't log out when accessing unauthorized URL

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -61,9 +61,7 @@ class ApplicationController < ActionController::Base
     else
       flash[:error] = t('common.log_in_to_view_page')
       if request.get? # Regular GET
-        redirect_to login_path(redirect_to: request.path)
-      elsif request.referer.nil?
-        redirect_to root_path
+        redirect_back(fallback_location: root_path)
       else
         redirect_to login_path(redirect_to: request_referer_if_on_current_domain)
       end


### PR DESCRIPTION
We currently log the user out when accessing an unauthorized URL.
This is annoying and is improved in this commit by just redirecting
back to the URL the user came from, which falls back to the root
page (the front page) when the HTTP_REFERER is nil.