### PR TITLE
Don't show all opening hours link when Samfundet is closed

### DIFF
--- a/app/views/layouts/_opening_hours.html.haml
+++ b/app/views/layouts/_opening_hours.html.haml
@@ -21,5 +21,5 @@
                 = format '%s–%s',
                     I18n.l(hours.open_time, format: :time),
                     I18n.l(hours.close_time, format: :time)
-    .opening-hours-link
-      = link_to t('site.index.all-opening-hours'), @opening_hours_url
+      .opening-hours-link
+        = link_to t('site.index.all-opening-hours'), @opening_hours_url


### PR DESCRIPTION
The indentation here is crucial: Indented one to the left, these
lines would fall after the else block, showing the all opening
hours all the time. We must indent them inside the else (obviously).