### PR TITLE
Make applicant phone number and email interactable

### DIFF
--- a/app/views/admissions_admin/jobs/_jobs_show.html.haml
+++ b/app/views/admissions_admin/jobs/_jobs_show.html.haml
@@ -66,8 +66,8 @@
               %td
                 = link_to admissions_admin_admission_group_job_job_application_path(@admission, @group, job_application.job, job_application) do
                   = job_application.applicant.full_name
-              %td= job_application.applicant.phone
-              %td= job_application.applicant.email
+              %td= link_to job_application.applicant.phone, "tel:#{job_application.applicant.phone}"
+              %td= mail_to job_application.applicant.email
               %td= job_application.applicant.campus
               - if show_job_titles
                 %td= job_application.title


### PR DESCRIPTION
Fixes #606

This commit enables you to click the phone number and email of an
applicant and then directly call the applicant or open up the mail
application to send an email to the applicant.