### PR TITLE
Add Makefile command to generate model/controller diagrams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ coverage
 .loadpath
 
 webrat-*.html
+
+docs/diagrams/

--- a/Makefile
+++ b/Makefile
@@ -50,3 +50,8 @@ truncate:
 
 setup-mac:
 	sh setup-mac.sh
+
+.PHONY: generate-diagrams
+generate-diagrams:
+	railroady -M | neato -Tsvg > docs/diagrams/models.svg
+	railroady -C | neato -Tsvg > docs/diagrams/controllers.svg

--- a/Makefile
+++ b/Makefile
@@ -53,5 +53,6 @@ setup-mac:
 
 .PHONY: generate-diagrams
 generate-diagrams:
+	[ -d docs/diagrams ] ||  mkdir docs/diagrams
 	railroady -M | neato -Tsvg > docs/diagrams/models.svg
 	railroady -C | neato -Tsvg > docs/diagrams/controllers.svg


### PR DESCRIPTION
This commit introduces the helpful Makefile command -
'generate-diagrams' that generates diagrams for our models and
controllers. Perhaps the models diagram is a bit more useful, but I
included both for completeness sake. Just run

```
make generate-diagrams
```

and they'll be regenerated in `/docs/diagrams`.