### PR TITLE
Update open hours, improve reservation error pages

### DIFF
--- a/app/controllers/sulten/lyche_controller.rb
+++ b/app/controllers/sulten/lyche_controller.rb
@@ -24,6 +24,7 @@ class Sulten::LycheController < Sulten::BaseController
 
   end
 
+  # Shown when reservation fails due to not being one day in future
   def reservation_failure_day
 
   end

--- a/app/controllers/sulten/lyche_controller.rb
+++ b/app/controllers/sulten/lyche_controller.rb
@@ -24,6 +24,10 @@ class Sulten::LycheController < Sulten::BaseController
 
   end
 
+  def reservation_failure_day
+
+  end
+
   def menu
 
   end

--- a/app/controllers/sulten/reservations_controller.rb
+++ b/app/controllers/sulten/reservations_controller.rb
@@ -33,7 +33,9 @@ class Sulten::ReservationsController < Sulten::BaseController
   def create
     @closed_periods = Sulten::ClosedPeriod.current_and_future_closed_times.sort_by(&:closed_from)
     @reservation = Sulten::Reservation.new(reservation_params)
-    if @reservation.in_closed_period?
+    if @reservation.reservation_is_one_day_in_future
+      redirect_to sulten_reservation_failure_day_path
+    elsif @reservation.in_closed_period?
       flash.now[:error] = t('helpers.models.sulten.reservation.errors.in_closed_period')
       redirect_to sulten_reservation_failure_path
     elsif @reservation.save

--- a/app/views/sulten/admin/index.html.haml
+++ b/app/views/sulten/admin/index.html.haml
@@ -148,7 +148,11 @@
         %td
           = k.reservation_type
         %td
-          = k.table.number
+          - if k.missing_table
+            %span{style: "color:red"}
+              = t("sulten.reservation.missing_table")
+          - else
+            = k.table.number
         %td
           = link_to t("crud.edit"), [:edit, k]
         %td

--- a/app/views/sulten/lyche/_status_box.html.haml
+++ b/app/views/sulten/lyche/_status_box.html.haml
@@ -8,13 +8,13 @@
           %b= "Åpningstider"
       %tr
         %td= "10.08 - 12.08"
-        %td= "22:00 - 00:00 (bar)"
+        %td= "20:00 - 00:00 (bar)"
       %tr
         %td= "13.08 - 28.08"
-        %td= "16:00 - 22:00 (restaurant)"
+        %td= "16:00 - 20:00 (restaurant)"
       %tr
         %td= ""
-        %td= "22:00 - 00:00 (spritbar)"
+        %td= "20:00 - 00:00 (spritbar)"
       %tr
         %td{colspan: 2}
           %b= "Etter fadderukene"

--- a/app/views/sulten/lyche/index.html.haml
+++ b/app/views/sulten/lyche/index.html.haml
@@ -9,7 +9,7 @@
       .title
         Reservasjon
       .description
-        På grunn av smittevernhensyn er det dessverre ikke mulig med drop-inn på Lyche. Alle besøk, både mat- og drikke relaterte, må reserveres. Dette gjøres gjennom vårt reservasjonssystem eller på e-post.
+        Vil du reservere bord på Lyche? Dette kan du gjøre gjennom vårt reservasjonssystem, eller på e-post.
       = link_to sulten_make_reservation_path do
         .section-button
           Reserver bord

--- a/app/views/sulten/lyche/menu.html.haml
+++ b/app/views/sulten/lyche/menu.html.haml
@@ -32,15 +32,15 @@
           %span{style:"color:white;"}
             Mandag 10.08 - Onsdag 12.08
           %br
-          %i="22:00 - 00:00 (spritbar)"
+          %i="20:00 - 00:00 (spritbar)"
           %br
           %br
           %span{style:"color:white;"}
             Torsdag 13.08 - søndag 28.08
           %br
-          %i="16:00 - 22:00 (restaurant)"
+          %i="16:00 - 20:00 (restaurant)"
           %br
-          %i="22:00 - 00:00 (spritbar)"
+          %i="20:00 - 00:00 (spritbar)"
           %br
           %br
           %div{style: "color:#fbb042;"}= "Etter fadderukene"

--- a/app/views/sulten/lyche/reservation.html.haml
+++ b/app/views/sulten/lyche/reservation.html.haml
@@ -7,7 +7,7 @@
 
 
   .reservation-info
-    På grunn av løpende smittevernhensyn så er det dessverre ikke mulig med drop-inn på Lyche. Alle besøk, både mat- og drikke relaterte, må reserveres i forveien. Dette gjøres gjennom vårt reservasjonssystem, eller på e-post.
+    Reservasjoner gjøres gjennom vårt reservasjonssystem, eller på e-post.
     Det er mulig å forhåndsbestille mat hvis dere kontakter oss med bestillingen på e-post minst et døgn i forveien av reservasjonen. Da kan vi ha maten klar til avtalt tidspunkt, og dere trenger ikke å vente på maten.
     %br
     %br

--- a/app/views/sulten/lyche/reservation_failure.html.haml
+++ b/app/views/sulten/lyche/reservation_failure.html.haml
@@ -7,3 +7,4 @@
 
   .reservation-info
     Kunne ikke opprette reservasjonen! Vennligst prøv igjen eller send oss en epost for å reservere bord.
+    Merk at reservasjoner må være en dag i forveien og på maks 12 personer.

--- a/app/views/sulten/lyche/reservation_failure.html.haml
+++ b/app/views/sulten/lyche/reservation_failure.html.haml
@@ -7,4 +7,4 @@
 
   .reservation-info
     Kunne ikke opprette reservasjonen! Vennligst prøv igjen eller send oss en epost for å reservere bord.
-    Merk at reservasjoner må være en dag i forveien og på maks 12 personer.
+    Merk at reservasjoner må være minst en dag i forveien og på maks 12 personer.

--- a/app/views/sulten/lyche/reservation_failure_day.html.haml
+++ b/app/views/sulten/lyche/reservation_failure_day.html.haml
@@ -6,4 +6,4 @@
     = t("sulten.reservation.form.title")
 
   .reservation-info
-    Beklager, vi kan ikke ta imot reservasjoner på dagen. Kom gjerne innom og se om det er plass!
+    Beklager, reservasjoner må være minst en dag i forveien. Kom gjerne innom og se om det er plass!

--- a/app/views/sulten/lyche/reservation_failure_day.html.haml
+++ b/app/views/sulten/lyche/reservation_failure_day.html.haml
@@ -1,0 +1,9 @@
+- content_for(:container) do
+  = render "header_menu"
+
+
+  .lyche_form_title
+    = t("sulten.reservation.form.title")
+
+  .reservation-info
+    Beklager, vi kan ikke ta imot reservasjoner på dagen. Kom gjerne innom og se om det er plass!

--- a/app/views/sulten/reservations/show.html.haml
+++ b/app/views/sulten/reservations/show.html.haml
@@ -17,7 +17,11 @@
     %th
       = t("sulten.reservation.table")
     %td
-      = @reservation.table
+      - if @reservation.missing_table
+        %span{style: "color:red"}
+          = t("sulten.reservation.missing_table")
+      - else
+        = @reservation.table.number
   %tr
     %th
       = t("sulten.reservation.reservation_type")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -176,6 +176,7 @@ Rails.application.routes.draw do
       get "/make_reservation" => "lyche#reservation"
       get "/reservation/success" => "lyche#reservation_success"
       get "/reservation/failure" => "lyche#reservation_failure"
+      get "/reservation/failure_day" => "lyche#reservation_failure_day"
       get "/menu" => "lyche#menu"
       get "/about" => "lyche#about"
       get "/contact" => "lyche#contact"


### PR DESCRIPTION
Lyche requested updated open hours after new government regulations and a more clear error page for reservations to prevent user confusion.

Also fixes -1 to show "Missing table"