### PR TITLE
[WIP] Fix statistics issues

### DIFF
--- a/app/controllers/admissions_admin/admissions_controller.rb
+++ b/app/controllers/admissions_admin/admissions_controller.rb
@@ -148,7 +148,7 @@ private
       f.chart({ defaultSeriesType: 'pie', margin: [50, 200, 60, 170] })
       series = {
         type: 'pie',
-        name: t('admissions_admin.applicants'),
+        name: t('admissions_admin.applications'),
         data: @applications_per_group
       }
       f.series(series)

--- a/config/locales/views/admissions_admin/en.yml
+++ b/config/locales/views/admissions_admin/en.yml
@@ -7,7 +7,7 @@ en:
     add_applicant_motivation: "Manually added by Web"
     add_applicant_not_found: "Did not find applicant"
     add_applicant_success: "Success! You added an applicant"
-    applications_by_group: "Distribution of applicants by group"
+    applications_by_group: "Distribution of applications by group"
     applications_by_day: "Number of applications per day"
     applications_by_hour: "Number of applications per hour"
     applications_by_campus: "Number of applications per campus"

--- a/config/locales/views/admissions_admin/no.yml
+++ b/config/locales/views/admissions_admin/no.yml
@@ -7,7 +7,7 @@
     add_applicant_motivation: "Manuelt lagt til av Web"
     add_applicant_not_found: "Fant ikke søker"
     add_applicant_success: "Suksess! Du la til en søker"
-    applications_by_group: "Fordeling av søkere per gjeng"
+    applications_by_group: "Fordeling av søknader per gjeng"
     applications_by_day: "Antall søknader per dag"
     applications_by_hour: "Antall søkere per time"
     applications_by_campus: "Antall søkere per campus"


### PR DESCRIPTION
- Fixes small issue where "Applicant" is used for "Application" statistics

I have looked into why the statistics page is so slow, and have found this function to be the greatest contributor:

```ruby
# Count unique applicants and how many of those were actually admitted to Samfundet
  # This is done both for Samfundet as a whole and for each group
  def count_unique_applicants_in_groups
    @applicants = {}

    @admission.groups.map do |group|
      @applicants[group] = { total: Set[], accepted: Set[] }

      applicants = group.job_applications_in_admission(@admission).map(&:applicant).uniq
      applicants.each do |app|
        @applicants[group][:total].add app.id

        log_entries = LogEntry.where(admission_id: @admission.id, applicant_id: app.id, group_id: group.id)

        unless log_entries.empty?
          last_log = log_entries.last
          if application_is_accepted?(last_log)
            @applicants[group][:accepted].add app.id
          end
        end
      end

      calculate_group_applicants_admitted_ratio(@applicants[group])
    end
  end
```

It seems that particularly this line is very expensive because it must be done for every applicant for every job:

```ruby
log_entries = LogEntry.where(admission_id: @admission.id, applicant_id: app.id, group_id: group.id)
```


