### PR TITLE
Fix lyche table reservations

### DIFF
--- a/app/controllers/sulten/lyche_controller.rb
+++ b/app/controllers/sulten/lyche_controller.rb
@@ -14,7 +14,12 @@ class Sulten::LycheController < Sulten::BaseController
   def reservation
     @closed_periods = Sulten::ClosedPeriod.current_and_future_closed_times.sort_by(&:closed_from)
     unless @closed_periods.empty?
-      @closed_periods = [@closed_periods.first]
+      # Show only if less than 60 days in future
+      if (@closed_periods.first.closed_from - Time.now) < 60.days
+        @closed_periods = [@closed_periods.first]
+      else
+        @closed_periods = []
+      end
     end
     @reservation = Sulten::Reservation.new
   end

--- a/app/controllers/sulten/lyche_controller.rb
+++ b/app/controllers/sulten/lyche_controller.rb
@@ -13,6 +13,9 @@ class Sulten::LycheController < Sulten::BaseController
 
   def reservation
     @closed_periods = Sulten::ClosedPeriod.current_and_future_closed_times.sort_by(&:closed_from)
+    unless @closed_periods.empty?
+      @closed_periods = [@closed_periods.first]
+    end
     @reservation = Sulten::Reservation.new
   end
 

--- a/app/models/sulten/reservation.rb
+++ b/app/models/sulten/reservation.rb
@@ -91,7 +91,7 @@ class Sulten::Reservation < ApplicationRecord
     (1..Sulten::ReservationType.count).each do |i|
       Sulten::Table.where('capacity >= ? and available = ?', people, true).order('capacity ASC').tables_with_i_reservation_types(i).find do |t|
         next unless t.reservation_types.pluck(:id).include? reservation_type_id
-        if t.reservations.where('reservation_from > ? or reservation_to < ?', to, from).count == t.reservations.count
+        if t.reservations.where('reservation_from >= ? or reservation_to <= ?', to, from).count == t.reservations.count
           return t
         end
       end

--- a/app/models/sulten/reservation.rb
+++ b/app/models/sulten/reservation.rb
@@ -68,7 +68,7 @@ class Sulten::Reservation < ApplicationRecord
   end
 
   def check_amount_of_people
-    if people > 12
+    if people > 8
       errors.add(:people, I18n.t('helpers.models.sulten.reservation.errors.people.too_many_people'))
     elsif people < 1
       errors.add(:people, I18n.t('helpers.models.sulten.reservation.errors.people.too_few_people'))

--- a/app/views/sulten/lyche/reservation.html.haml
+++ b/app/views/sulten/lyche/reservation.html.haml
@@ -32,7 +32,7 @@
           = mail_to "lyche@samfundet.no", "mail."
       = f.input :people, label: t("sulten.reservation.people"),as: :number
       = f.input :reservation_from, placeholder: t("sulten.reservation.placeholder_date"), label: t("sulten.reservation.form.from"), input_html: { class: "datetimepicker_lyche"}, as: :string
-      = f.input :reservation_duration, label: t("sulten.reservation.form.duration"), collection: [60, 90, 120, 150, 180], member_label: proc{|d| "#{d} minutter"}, include_blank: false, selected: 60
+      = f.hidden_field :reservation_duration, value: 120
 
       .form-divider
 

--- a/app/views/sulten/lyche/reservation.html.haml
+++ b/app/views/sulten/lyche/reservation.html.haml
@@ -6,18 +6,13 @@
     = t("sulten.reservation.form.title")
 
   .reservation-info
-
     Bord må reserveres senest en dag i forveien. Mat kan forhåndsbestilles slik at dere ikke trenger å vente når dere kommer.
     Merk at flertallet av personer må være medlem for å reservere og at alle må være over 20 år etter kl 20:00 i helger.
     Med hensyn til smittevern kan vi ikke garantere at alle får sittet sammen.
     %br
     %br
-    Klikk her for å bestille via epost:
-    %br
+    Reservasjonssystemet vårt er fortsatt under utvikling, og vi ber om forbehold om at feil kan forekomme. Klikk her for å bestille via epost:
     = mail_to "lyche@samfundet.no"
-    %br
-    %br
-    Reservasjonssystemet vårt er fortsatt under utvikling, og ber om forbehold om at feil kan forekomme.
     %br
     %br
     - @closed_periods.each do |c|

--- a/app/views/sulten/lyche/reservation.html.haml
+++ b/app/views/sulten/lyche/reservation.html.haml
@@ -5,21 +5,24 @@
   .lyche_form_title
     = t("sulten.reservation.form.title")
 
-
   .reservation-info
-    Bord må reserveres senest en dag før og gjøres over e-post.
-    Det er mulig å forhåndsbestille mat hvis dere kontakter oss med bestillingen minst et døgn i forveien av reservasjonen.
-    Da kan vi ha maten klar til avtalt tidspunkt, og dere trenger ikke å vente på maten.
-    Merk at flertallet av personer må være medlem for å reservere og at alle må være over 20 år etter kl 20:00 i helger. Med hensyn til smittevern kan vi ikke garantere at alle får sittet sammen.
+
+    Bord må reserveres senest en dag i forveien. Mat kan forhåndsbestilles slik at dere ikke trenger å vente når dere kommer.
+    Merk at flertallet av personer må være medlem for å reservere og at alle må være over 20 år etter kl 20:00 i helger.
+    Med hensyn til smittevern kan vi ikke garantere at alle får sittet sammen.
     %br
     %br
-    Klikk her for å sende mail:
+    Klikk her for å bestille via epost:
     %br
     = mail_to "lyche@samfundet.no"
     %br
     %br
     Reservasjonssystemet vårt er fortsatt under utvikling, og ber om forbehold om at feil kan forekomme.
     %br
+    %br
+    - @closed_periods.each do |c|
+      %i
+        = "Lyche holder stengt i perioden " + l(c.closed_from, format: :short_date) + " - " + l(c.closed_to, format: :short_date)
     %br
   = semantic_form_for @reservation, :html => { :class => "custom-form lyche_form"} do |f|
     = f.inputs do

--- a/app/views/sulten/lyche/reservation_failure.html.haml
+++ b/app/views/sulten/lyche/reservation_failure.html.haml
@@ -7,4 +7,7 @@
 
   .reservation-info
     Kunne ikke opprette reservasjonen! Vennligst prøv igjen eller send oss en epost for å reservere bord.
-    Merk at reservasjoner må være minst en dag i forveien og på maks 12 personer.
+    Merk at reservasjoner må være minst en dag i forveien og på maks 8 personer.
+
+    Klikk her for å prøve å bestille via epost:
+    = mail_to "lyche@samfundet.no"

--- a/config/locales/models/sulten/en.yml
+++ b/config/locales/models/sulten/en.yml
@@ -22,7 +22,7 @@ en:
               check_opening_hours: "Lyche is closed during the given period of time"
             reservation_type_present: "the occasion field cannot be left empty"
             people:
-              too_many_people: "send reservations with more than 12 persons to lyche@samfundet.no"
+              too_many_people: "send reservations with more than 8 persons to lyche@samfundet.no"
               too_few_people: "the reservation must be made for at least one person"
             check_reservation_duration: "the reservation duration must be selected from the collection specified"
             invalid_reservation_format: "Invalid format. Try this format: 20.10.2016 16:00"

--- a/config/locales/models/sulten/no.yml
+++ b/config/locales/models/sulten/no.yml
@@ -22,7 +22,7 @@
               check_opening_hours: "Lyche er lukket under dette tidsrommet"
             reservation_type_present: "anledningfeltet kan ikke settes tomt"
             people:
-              too_many_people: "bestillinger med flere enn 12 personer må sendes på mail til lyche@samfundet.no"
+              too_many_people: "bestillinger med flere enn 8 personer må sendes på mail til lyche@samfundet.no"
               too_few_people: "det må være minst én person på en reservasjon"
             check_reservation_duration: "reservasjonslengden må velges blant de angitte tidene"
             invalid_reservation_format: "Feil format. Prøv formatet: 20.10.2016 16:00"

--- a/config/locales/views/sulten/en.yml
+++ b/config/locales/views/sulten/en.yml
@@ -37,7 +37,7 @@ en:
         intro1_admin: "This is what users see:"
         intro2: "Currently you may only make reservations for time periods between 4 pm and 10 pm, and a reservation must be made no later than the day before it begins."
         intro3: "In order to change or cancel a reservation, please send an email to "
-        too_many: "more than 12 persons? send us a "
+        too_many: "more than 8 persons? send us a "
         from: "beginning time of reservation"
         duration: "duration"
         type_explanation: "what is the purpose of the visit? this helps determine the sort of table you will be given"

--- a/config/locales/views/sulten/no.yml
+++ b/config/locales/views/sulten/no.yml
@@ -39,7 +39,7 @@
         intro1_admin: "Dette er hva brukere ser:"
         intro2: "Foreløpig kan en bare reservere bord mellom kl. 16:00 - 22:00 og reservasjonen må gjøres minst ett døgn i forveien."
         intro3: "For å endre eller avbestille en reservasjon, vennligst send mail til "
-        too_many: "Flere enn 12 personer? Send oss en "
+        too_many: "Flere enn 8 personer? Send oss en "
         from: "Tidspunkt"
         duration: "Varighet"
         type_explanation: "Vi bruker dette for å tildele et passende bord."


### PR DESCRIPTION
- Fixes bug where reservations could be made when no tables were available
- Allows reservations to overlap on-the-clock (eg. two reservations from 18:00-20:00 and 20:00-21:00)
- Adds info about closed periods to reservation form 
- Implements 8 person limit on online reservations
- Cleans up text a bit
- **Reenables online reservation system!**
