### PR TITLE
Group admission groups by letter on overview page

### DIFF
--- a/app/assets/stylesheets/modern/util.scss
+++ b/app/assets/stylesheets/modern/util.scss
@@ -91,6 +91,12 @@ hr {
   margin-bottom: 1.5em;
 }
 
+hr.compact {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+  height: 1px;
+}
+
 // To uppercase
 .up-ca { text-transform: uppercase;}
 

--- a/app/views/admissions_admin/admissions/show.html.haml
+++ b/app/views/admissions_admin/admissions/show.html.haml
@@ -17,11 +17,28 @@
 %h1.mt-3.mb-2
   = set_and_return_title T('admissions.my_groups')
 
-.flex-row.wrap
-  - @my_groups.sort.each do |group|
-    = link_to admissions_admin_admission_group_path(@admission, group) do
-      .samf-button.plain.small.mb-2.mr-2
-        = group.name
+%div
   - if @my_groups.empty?
     %li
       %p= t('admissions.no_groups')
+  - elsif @my_groups.count < 5
+    -# Dont group by letter if < 5
+    .flex-row-wrap
+      - @my_groups.sort.each do |g|
+        = link_to admissions_admin_admission_group_path(@admission, g) do
+          .samf-button.plain.small.mb-1.mt-1.mr-2{style: "float: left;"}
+            = g.name
+  - else
+    -# Group by letter
+    - ("A".."Å").each do |l|
+      - groups = @my_groups.select { |g| g.name[0].upcase == l }.sort
+      - if groups.count > 0
+        %hr.compact
+        .flex-row.flex-align-center
+          %h1.mr-3{style: "color: #555; font-family: monospace;"}= l
+
+          .flex-row.wrap
+            - groups.each do |group|
+              = link_to admissions_admin_admission_group_path(@admission, group) do
+                .samf-button.plain.small.mb-1.mt-1.mr-2{style: "float: left;"}
+                  = group.name

--- a/app/views/admissions_admin/admissions/show.html.haml
+++ b/app/views/admissions_admin/admissions/show.html.haml
@@ -35,7 +35,7 @@
       - if groups.count > 0
         %hr.compact
         .flex-row.flex-align-center
-          %h1.mr-3{style: "color: #555; font-family: monospace;"}= l
+          %h1.mr-3{style: "color: #aaa; font-family: monospace;"}= l
 
           .flex-row.wrap
             - groups.each do |group|

--- a/app/views/admissions_admin/admissions/show.html.haml
+++ b/app/views/admissions_admin/admissions/show.html.haml
@@ -23,7 +23,7 @@
       %p= t('admissions.no_groups')
   - elsif @my_groups.count < 5
     -# Dont group by letter if < 5
-    .flex-row-wrap
+    .flex-row.wrap
       - @my_groups.sort.each do |g|
         = link_to admissions_admin_admission_group_path(@admission, g) do
           .samf-button.plain.small.mb-1.mt-1.mr-2{style: "float: left;"}


### PR DESCRIPTION
When you are responsible for a lot of group admissions, the list becomes difficult to search. This PR adds grouping by first letter if there are >= 5 groups:

<img width="549" alt="Screenshot 2020-11-21 at 19 55 53" src="https://user-images.githubusercontent.com/21267642/99885202-9209c480-2c33-11eb-9f88-12a13847b571.png">
