### PR TITLE
Disable db log output

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,4 +68,6 @@ Samfundet::Application.configure do
 
   config.middleware.insert_after ActionDispatch::Static, Rack::LiveReload
 
+  ActiveRecord::Base.logger = nil
+  config.log_level = :info
 end


### PR DESCRIPTION
Disable the log output in the console for the SQL queries, for easier development.

User should run rake db:setup first however.