### PR TITLE
Make date text input field readonly for lyche reservations

### DIFF
--- a/app/views/sulten/lyche/reservation.html.haml
+++ b/app/views/sulten/lyche/reservation.html.haml
@@ -57,7 +57,7 @@
 
         .form-divider
 
-        = f.input :reservation_from, label: "Dato", input_html: { class: "datepicker", value: @reservation.reservation_from}, as: :string
+        = f.input :reservation_from, label: "Dato", input_html: { class: "datepicker", value: @reservation.reservation_from, :readonly => "readonly"}, as: :string
 
         .form-divider
         = f.actions do


### PR DESCRIPTION
This might fix previous bugs with "invalid_date" in the lyche controller.

Previously, the user was able to type in anything in the date text field.
This option is now removed, as the text field is set to readonly.
Only inputs from the calendar are now accepted.

Still unsure how the users were able to get "reservation_from"=>"NaN.NaN.NaN" in previous errors.
Will look into this bug a bit more later, when I have the time.