### PR TITLE
Add test email form on admission overview

### DIFF
--- a/app/controllers/admissions_admin/admissions_controller.rb
+++ b/app/controllers/admissions_admin/admissions_controller.rb
@@ -105,6 +105,32 @@ class AdmissionsAdmin::AdmissionsController < AdmissionsAdmin::BaseController
     }
   end
 
+  # Test email
+  def send_test_email
+    @template = {
+        sender: params[:sender],
+        reply_to: params[:reply_to],
+        subject: params[:subject],
+        intro: params[:intro],
+        content: params[:content],
+        recipient: params[:recipient]
+    }
+
+    if not @template[:sender].end_with?("@samfundet.no")
+      flash[:error] = "Avsender må være en @samfundet.no epost."
+      redirect_back fallback_location: root_path
+      return
+    end
+
+    begin
+      AdmissionRejectionMailer.send_test_email(@template).deliver
+      flash[:success] = "Sendte epost til #{@template[:recipient]}"
+    rescue Error => e
+      flash[:error] = "Kunne ikke sende epost: #{e}"
+    end
+    redirect_back fallback_location: root_path
+  end
+
   # Async response for send rejection email
   def send_rejection_email_result
     # Get recipients

--- a/app/mailers/admission_rejection_mailer.rb
+++ b/app/mailers/admission_rejection_mailer.rb
@@ -9,4 +9,15 @@ class AdmissionRejectionMailer < ActionMailer::Base
     @template = template
     mail(to: applicant.email, subject: @template[:subject])
   end
+
+  def send_test_email(template)
+    @template = template
+    mail(
+        from: template[:sender],
+        reply_to: template[:reply_to],
+        to: template[:recipient],
+        subject: template[:subject],
+    )
+  end
+
 end

--- a/app/views/admission_rejection_mailer/send_test_email.text.erb
+++ b/app/views/admission_rejection_mailer/send_test_email.text.erb
@@ -1,0 +1,1 @@
+<%= @template[:content] %>

--- a/app/views/admissions_admin/admissions/overview.html.haml
+++ b/app/views/admissions_admin/admissions/overview.html.haml
@@ -82,3 +82,24 @@
 - if @sent_rejection_emails > 0 and (@missing.count > 0 or not @admission_complete)
   %hr
   %p{style: "color: red; font-weight: bold;"}= t("admissions_admin.overview_missing", count: @missing.count)
+
+
+- if current_user.roles.include? Role.super_user
+  %hr
+  %h1= "Test Epostsystem (Vises kun for MG Web)"
+  = form_with(id: "send_rejection_email_form", url: {:controller=>'admissions_admin/admissions', :action=>'send_test_email'}) do |f|
+    %h2= "Avsender"
+    = f.text_field :sender, :value => "opptaksansvarlig@samfundet.no"
+    %h2= "Svar Til"
+    = f.text_field :reply_to, :value => "opptaksansvarlig@samfundet.no"
+    %h2= "Mottaker"
+    = f.text_field :recipient, :value => "mg-web@samfundet.no"
+    %hr.compact
+    %h2= "Tittel"
+    = f.text_area :subject, :value => "Test Epost"
+    %h2= "Innhold"
+    = f.text_area :content, :value => "Dette er en test-epost."
+    %br
+    %br
+    = f.submit "Send test-epost", data: { confirm: "Er du sikker på at testepost skal sendes?" }
+    %hr

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,6 +145,7 @@ Rails.application.routes.draw do
         post :review_rejection_email, on: :member
         post :send_rejection_email, on: :member
         post :send_rejection_email_result, on: :member
+        post :send_test_email, on: :member
         get :rejection_email_list, on: :member
 
         resources :groups, only: :show do


### PR DESCRIPTION
Adds an option to send a test email from any @samfundet email to any recipient.
Useful for testing that the email system works before rejection emails are sent.