### PR TITLE
Fix withdrawn application issue for interview prioritization

### DIFF
--- a/app/controllers/admissions_admin/groups_controller.rb
+++ b/app/controllers/admissions_admin/groups_controller.rb
@@ -42,11 +42,11 @@ class AdmissionsAdmin::GroupsController < AdmissionsAdmin::BaseController
 
         job_application = applicant.top_priority_job_application_at_group_without_interview(@admission, @group)
         priority = applicant.priority_of_job_application(@admission, job_application)
-        number_of_group_applications = applicant.open_job_applications_in_group(@admission, @group).length
-        number_of_total_applications = applicant.open_job_applications(@admission).length
+        group_jobs_applied_to = applicant.open_job_applications_in_group(@admission, @group).length
+        total_jobs_applied_to = applicant.open_job_applications(@admission).length
         job_title = job_application.title
 
-        @top_job_applications.push([priority, job_application, job_title, applicant.full_name, applicant.phone, applicant.email, number_of_group_applications, number_of_total_applications])
+        @top_job_applications.push([priority, job_application, job_title, applicant.full_name, applicant.phone, applicant.email, group_jobs_applied_to, total_jobs_applied_to])
       end
     end
 

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -139,7 +139,7 @@ class Applicant < ApplicationRecord
   end
 
   def priority_of_job_application(admission, job_application)
-    job_applications.select { |application| application.job.admission == admission }.index(job_application) + 1
+    job_applications.select { |application| application.job.admission == admission && application.withdrawn == false }.index(job_application) + 1
   end
 
   def priority_of_job_application_string(admission, job_application)

--- a/app/views/admissions_admin/job_applications/show.html.haml
+++ b/app/views/admissions_admin/job_applications/show.html.haml
@@ -115,7 +115,7 @@
           - tr_class = "#{job_application.assignment_status}"
           %tr{id: "application-#{job_application.id}", class: tr_class}
             %td
-              = job_application.applicant.priority_of_job_application(admission, job_application).to_s + " / " + job_application.applicant.jobs_applied_to(admission).length.to_s
+              = job_application.applicant.priority_of_job_application(admission, job_application).to_s + " / " + job_application.applicant.open_job_applications(admission).length.to_s
             %td
               = link_to admissions_admin_admission_group_job_path(admission, group, job) do
                 = job.title
@@ -148,7 +148,7 @@
                   != form.action :submit, button_html: { class: "interview_save", value: t('interviews.save_interview_status') }
                 %span{ class: "status" }
             %td
-              = job_application.applicant.get_set_interviews(admission).length.to_s + " / " + job_application.applicant.jobs_applied_to(admission).length.to_s
+              = job_application.applicant.get_set_interviews(admission).length.to_s + " / " + job_application.applicant.open_job_applications(admission).length.to_s
             %td
               = semantic_form_for([:admissions_admin, admission, group, job, job_application, interview = job_application.find_or_create_interview], namespace: "interview_#{interview.id}", html: {class: "test custom-form"}) do |form|
                 = form.inputs do

--- a/app/views/admissions_admin/jobs/_jobs_show.html.haml
+++ b/app/views/admissions_admin/jobs/_jobs_show.html.haml
@@ -109,9 +109,9 @@
                 != form.action :submit, button_html: { class: "interview_save", value: t('interviews.save_interview_status') }
               %span{ class: "status" }
           %td
-            = job_application.applicant.priority_of_job_application(@admission, job_application).to_s + " / " + job_application.applicant.jobs_applied_to(@admission).length.to_s
+            = job_application.applicant.priority_of_job_application(@admission, job_application).to_s + " / " + job_application.applicant.open_job_applications(@admission).length.to_s
           %td
-            = job_application.applicant.get_set_interviews(@admission).length.to_s + " / " + job_application.applicant.jobs_applied_to(@admission).length.to_s
+            = job_application.applicant.get_set_interviews(@admission).length.to_s + " / " + job_application.applicant.open_job_applications(@admission).length.to_s
           -#%td
           -#  - if job_application.last_log_entry
           -#    = link_to admissions_admin_admission_group_job_job_application_path(@admission, @group, job_application.job, job_application, anchor: 'new_log_entry') do


### PR DESCRIPTION
Admission system cannot take into account withdrawn applicants, for prioritizing setting interviews. Therefore we need to only count open applications.