### PR TITLE
[Change] Add E-mail confirmation field for applicant registration

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -185,7 +185,7 @@ class ApplicantsController < ApplicationController
 private
 
   def applicant_params
-    params.require(:applicant).permit(:firstname, :surname, :phone, :campus_id, :email, :password, :password_confirmation, :interested_other_positions, :gdpr_checkbox)
+    params.require(:applicant).permit(:firstname, :surname, :phone, :campus_id, :email, :email_confirmation, :password, :password_confirmation, :interested_other_positions, :gdpr_checkbox)
   end
 
   def send_verification_email(applicant)

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -18,7 +18,7 @@ class Applicant < ApplicationRecord
   validates :email, :email_confirmation,
             presence: { if: ->(applicant) { applicant.new_record? } }
   validates :email, confirmation: { if: ->(applicant) { applicant.new_record? } }
-  validates :email, format: { with: /\A\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,4})+\z/ }
+  validates :email, format: { with: /\A.+@[a-z\d\-.]+\.[a-z]{2,}\z/i }
 
   validates :gdpr_checkbox, acceptance: true
 
@@ -134,7 +134,7 @@ class Applicant < ApplicationRecord
 
   class << self
     def valid_email?(field)
-      /\A\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,4})+\z/.match?(field)
+      /\A.+@[a-z\d\-.]+\.[a-z]{2,}\z/i.match?(field)
     end
 
     def valid_phone?(field)

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -18,7 +18,7 @@ class Applicant < ApplicationRecord
   validates :email, :email_confirmation,
             presence: { if: ->(applicant) { applicant.new_record? } }
   validates :email, confirmation: { if: ->(applicant) { applicant.new_record? } }
-  validates :email, format: { with: /\A\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+\z/ }
+  validates :email, format: { with: /\A\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,4})+\z/ }
 
   validates :gdpr_checkbox, acceptance: true
 
@@ -134,7 +134,7 @@ class Applicant < ApplicationRecord
 
   class << self
     def valid_email?(field)
-      /\A\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+\z/.match?(field)
+      /\A\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,4})+\z/.match?(field)
     end
 
     def valid_phone?(field)

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -10,12 +10,14 @@ class Applicant < ApplicationRecord
     foreign_key: 'applicant_id'
   belongs_to :campus
 
-  attr_accessor :password, :password_confirmation, :old_password, :gdpr_checkbox
+  attr_accessor :email_confirmation, :password, :password_confirmation, :old_password, :gdpr_checkbox
 
   validates :firstname, :surname, :email, :phone, :campus, presence: true
   validates :email, :phone, uniqueness: true
 
-  validates :email, email: true
+  validates :email, :email_confirmation,
+            presence: { if: ->(applicant) { applicant.new_record? } }
+  validates :email, confirmation: { if: ->(applicant) { applicant.new_record? } }
   validates :email, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
 
   validates :gdpr_checkbox, acceptance: true

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -18,7 +18,7 @@ class Applicant < ApplicationRecord
   validates :email, :email_confirmation,
             presence: { if: ->(applicant) { applicant.new_record? } }
   validates :email, confirmation: { if: ->(applicant) { applicant.new_record? } }
-  validates :email, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
+  validates :email, format: { with: /\A\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+\z/ }
 
   validates :gdpr_checkbox, acceptance: true
 
@@ -134,7 +134,7 @@ class Applicant < ApplicationRecord
 
   class << self
     def valid_email?(field)
-      /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.match?(field)
+      /\A\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+\z/.match?(field)
     end
 
     def valid_phone?(field)

--- a/app/views/applicants/_form.html.haml
+++ b/app/views/applicants/_form.html.haml
@@ -10,8 +10,8 @@
         != form.input :campus_id, as: :select, collection: Campus.order(:name)
 
     = form.inputs name: t("applicants.forms.register.login_information") do
-      != form.input :email, input_html: { value: @applicant_login_email }
-      != form.input :email_confirmation, input_html: { value: "" }
+      != form.input :email, input_html: { type: "email", value: @applicant_login_email }
+      != form.input :email_confirmation, input_html: { type: "email", value: "" }
       != form.input :password, input_html: { value: "" }
       != form.input :password_confirmation, input_html: { value: "" }
 

--- a/app/views/applicants/_form.html.haml
+++ b/app/views/applicants/_form.html.haml
@@ -11,8 +11,9 @@
 
     = form.inputs name: t("applicants.forms.register.login_information") do
       != form.input :email, input_html: { value: @applicant_login_email }
-      != form.input :password, input_html: {value: ""}
-      != form.input :password_confirmation, input_html: {value: ""}
+      != form.input :email_confirmation, input_html: { value: "" }
+      != form.input :password, input_html: { value: "" }
+      != form.input :password_confirmation, input_html: { value: "" }
 
     = form.inputs name: t("applicants.forms.register.extra_information") do
       != form.input :interested_other_positions, as: :select, hint: t("applicants.interested_other_positions_hint")

--- a/config/locales/activerecord_en.yml
+++ b/config/locales/activerecord_en.yml
@@ -1,38 +1,40 @@
 en:
   activerecord:
-      errors:
-        models:
-          applicant:
-            attributes:
-              password:
-                too_short: "The password is too short, must be at least %{count} characters."
-              password_confirmation:
-                confirmation: "Password confirmation does not match."
-        template:
-          header: "Could not save %{model} beause %{count} is wrong."
-          body: "problems arose because of the following fields:"
-        messages:
-          inclusion: "is not included in the list"
-          exclusion: "is reserved"
-          invalid: "is invalid"
-          confirmation: "does not fit the confirmation"
-          accepted: "must be accepted"
-          empty: "can not be empty"
-          blank: "can not be blank"
-          too_long: "is too long (maximum %{count} characters)"
-          too_short: "is too short (minimum %{count} characters)"
-          wrong_length: "is the wrong length (maximum %{count} characters)"
-          taken: "is already in use"
-          not_a_number: "is not a number"
-          greater_than: "must be greater than %{count}"
-          greater_than_or_equal_to: "must be greather than or equal to %{count}"
-          equal_to: "must be equal to %{count}"
-          less_than: "must be less than %{count}"
-          less_than_or_equal_to: "must be less than or equal to %{count}"
-          odd: "must be odd"
-          even: "must be even"
-          record_invalid: "Validation failed: %{errors}"
-        full_messages:
-          format: "%{attribute} %{message}"
-        # models:
-        # attributes:
+    errors:
+      models:
+        applicant:
+          attributes:
+            email:
+              invalid: "Invalid e-mail address"
+            password:
+              too_short: "The password is too short, must be at least %{count} characters."
+            password_confirmation:
+              confirmation: "Passwords do not match."
+      template:
+        header: "Could not save %{model} beause %{count} is wrong."
+        body: "problems arose because of the following fields:"
+      messages:
+        inclusion: "is not included in the list"
+        exclusion: "is reserved"
+        invalid: "is invalid"
+        confirmation: "does not fit the confirmation"
+        accepted: "must be accepted"
+        empty: "can not be empty"
+        blank: "can not be blank"
+        too_long: "is too long (maximum %{count} characters)"
+        too_short: "is too short (minimum %{count} characters)"
+        wrong_length: "is the wrong length (maximum %{count} characters)"
+        taken: "is already in use"
+        not_a_number: "is not a number"
+        greater_than: "must be greater than %{count}"
+        greater_than_or_equal_to: "must be greather than or equal to %{count}"
+        equal_to: "must be equal to %{count}"
+        less_than: "must be less than %{count}"
+        less_than_or_equal_to: "must be less than or equal to %{count}"
+        odd: "must be odd"
+        even: "must be even"
+        record_invalid: "Validation failed: %{errors}"
+      full_messages:
+        format: "%{attribute} %{message}"
+      # models:
+      # attributes:

--- a/config/locales/activerecord_no.yml
+++ b/config/locales/activerecord_no.yml
@@ -1,51 +1,55 @@
-'no':
+"no":
   activerecord:
-      errors:
-        models:
-          applicant:
-            attributes:
-              password:
-                too_short: "Passordet er for kort, må være minst %{count} tegn"
-              password_confirmation:
-                confirmation: "Bekreftelsen er ikke den samme"
-          event:
-            attributes:
-              start_time:
-                after: "Dette tidspunktet har passert."
-        template:
-          header: "kunne ikke lagre %{model} på grunn av %{count} feil."
-          body: "det oppstod problemer i følgende felt:"
-        messages:
-          inclusion: "er ikke inkludert i listen"
-          exclusion: "er reservert"
-          invalid: "er ugyldig"
-          confirmation: "passer ikke bekreftelsen"
-          accepted: "må være akseptert"
-          empty: "kan ikke være tom"
-          blank: "kan ikke være blank"
-          too_long: "er for lang (maksimum %{count} tegn)"
-          too_short: "er for kort (minimum %{count} tegn)"
-          wrong_length: "er av feil lengde (maksimum %{count} tegn)"
-          taken: "er allerede i bruk"
-          not_a_number: "er ikke et tall"
-          greater_than: "må være større enn %{count}"
-          greater_than_or_equal_to: "må være større enn eller lik %{count}"
-          equal_to: "må være lik %{count}"
-          less_than: "må være mindre enn %{count}"
-          less_than_or_equal_to: "må være mindre enn eller lik %{count}"
-          odd: "må være oddetall"
-          even: "må være partall"
-          record_invalid: "Validering feilet: %{errors}"
-        full_messages:
-          format: "%{attribute} %{message}"
-        # models:
-        # attributes:
+    errors:
+      models:
+        applicant:
+          attributes:
+            email:
+              invalid: "Ugyldig e-post"
+            email-confirmation:
+              confirmation: "E-post adressene samsvarer ikke"
+            password:
+              too_short: "Passordet er for kort, må være minst %{count} tegn"
+            password_confirmation:
+              confirmation: "Passordene samsvarer ikke"
+        event:
+          attributes:
+            start_time:
+              after: "Dette tidspunktet har passert."
+      template:
+        header: "kunne ikke lagre %{model} på grunn av %{count} feil."
+        body: "det oppstod problemer i følgende felt:"
+      messages:
+        inclusion: "er ikke inkludert i listen"
+        exclusion: "er reservert"
+        invalid: "er ugyldig"
+        confirmation: "passer ikke bekreftelsen"
+        accepted: "må være akseptert"
+        empty: "kan ikke være tom"
+        blank: "kan ikke være blank"
+        too_long: "er for lang (maksimum %{count} tegn)"
+        too_short: "er for kort (minimum %{count} tegn)"
+        wrong_length: "er av feil lengde (maksimum %{count} tegn)"
+        taken: "er allerede i bruk"
+        not_a_number: "er ikke et tall"
+        greater_than: "må være større enn %{count}"
+        greater_than_or_equal_to: "må være større enn eller lik %{count}"
+        equal_to: "må være lik %{count}"
+        less_than: "må være mindre enn %{count}"
+        less_than_or_equal_to: "må være mindre enn eller lik %{count}"
+        odd: "må være oddetall"
+        even: "må være partall"
+        record_invalid: "Validering feilet: %{errors}"
+      full_messages:
+        format: "%{attribute} %{message}"
+      # models:
+      # attributes:
   activemodel:
     errors:
       models:
         contact_form:
           attributes:
             email:
-              invalid: 'Ugyldig e-post'
+              invalid: "Ugyldig e-post"
             description:
-              too_short: 'Beskrivelsen er fort kort, minimum 50 bokstaver'
+              too_short: "Beskrivelsen er fort kort, minimum 50 bokstaver"

--- a/config/locales/models/applicant/en.yml
+++ b/config/locales/models/applicant/en.yml
@@ -8,7 +8,8 @@ en:
       applicant:
         firstname: "First name"
         surname: "Surname"
-        email: "Email"
+        email: "E-mail"
+        email_confirmation: "E-mail confirmation"
         hashed_password:
         phone: "Phone number"
         age: "Age"

--- a/config/locales/models/applicant/no.yml
+++ b/config/locales/models/applicant/no.yml
@@ -9,6 +9,7 @@
         firstname: "Fornavn"
         surname: "Etternavn"
         email: "E-post"
+        email_confirmation: "Bekreft E-post"
         hashed_password:
         password: Passord
         password_confirmation: Bekreft passord

--- a/db/seeds/applicants.seeds.rb
+++ b/db/seeds/applicants.seeds.rb
@@ -41,6 +41,7 @@ after :generate_roles do
       surname: Faker::Name.last_name,
       phone: phone_number,
       email: email,
+      email_confirmation: email,
       campus: Campus.order(Arel.sql('random()')).first,
       password: 'passord',
       password_confirmation: 'passord',

--- a/lib/validators/email_validator.rb
+++ b/lib/validators/email_validator.rb
@@ -2,7 +2,7 @@
 
 class EmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    unless /\A\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,4})+\z/.match?(value)
+    unless /\A.+@[a-z\d\-.]+\.[a-z]{2,}\z/i.match?(value)
       record.errors[attribute] << (options[:message] || 'is not a valid e-mail')
     end
   end

--- a/lib/validators/email_validator.rb
+++ b/lib/validators/email_validator.rb
@@ -2,8 +2,8 @@
 
 class EmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    unless /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i.match?(value)
-      record.errors[attribute] << (options[:message] || 'is not an email')
+    unless /\A\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,4})+\z/.match?(value)
+      record.errors[attribute] << (options[:message] || 'is not a valid e-mail')
     end
   end
 end


### PR DESCRIPTION
### **Changes**

**1.** Adds this field for applicants that register during admissions:

![image](https://github.com/Samfundet/Samfundet/assets/48588529/b2ad226d-fe50-4c99-8667-d5fe0d4a14aa)
The e-mail fields must be equal for the registration to complete.

**2.** Adds regexp validation on e-mail addresses that are registered.

The point is to ensure the correctness of the e-mail addresses that applicants are registered with.
As of now, applicants can type in almost anything in the email field, as long as it contains an @.
And they are logged in immediately after registration completes, and are free to apply to jobs.

My editor also automatically fixed tabbing in active record locales.