### PR TITLE
[Change] Add possibility to login with phone number as applicant

### DIFF
--- a/app/controllers/applicant_sessions_controller.rb
+++ b/app/controllers/applicant_sessions_controller.rb
@@ -11,7 +11,7 @@ class ApplicantSessionsController < UserSessionsController
 
   def create
     applicant = Applicant.authenticate(
-      params[:applicant_login_email],
+      params[:applicant_login_field],
       params[:applicant_login_password]
     )
 
@@ -19,7 +19,7 @@ class ApplicantSessionsController < UserSessionsController
       flash[:error] = t('applicants.login_error')
 
       @applicant = Applicant.new
-      @applicant_login_email = params[:applicant_login_email]
+      @applicant_login_field = params[:applicant_login_field]
       render :new
       return
     end

--- a/app/controllers/applicant_sessions_controller.rb
+++ b/app/controllers/applicant_sessions_controller.rb
@@ -15,11 +15,11 @@ class ApplicantSessionsController < UserSessionsController
       params[:applicant_login_password]
     )
 
-    if applicant.nil?
 
-      if match_email?(params[:applicant_login_field])
+    if applicant.nil?
+      if Applicant.valid_email?(params[:applicant_login_field])
         @applicant_login_email = params[:applicant_login_field]
-      elsif match_phone?(params[:applicant_login_field])
+      elsif Applicant.valid_phone?(params[:applicant_login_field])
         @applicant_login_phone = params[:applicant_login_field]
       else
         flash[:error] = t('applicants.login_input_error')
@@ -27,8 +27,8 @@ class ApplicantSessionsController < UserSessionsController
         return
       end
 
-      flash[:error] = t('applicants.login_error')
       @applicant = Applicant.new
+      flash[:error] = t('applicants.login_error')
 
       render :new
       return
@@ -47,14 +47,6 @@ class ApplicantSessionsController < UserSessionsController
   end
 
 private
-
-  def match_email?(field)
-    /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.match?(field)
-  end
-
-  def match_phone?(field)
-    /\A[\d\s+]+\z/.match?(field)
-  end
 
   def login_applicant(applicant)
     session[:applicant_id] = applicant.id

--- a/app/controllers/applicant_sessions_controller.rb
+++ b/app/controllers/applicant_sessions_controller.rb
@@ -16,15 +16,19 @@ class ApplicantSessionsController < UserSessionsController
     )
 
     if applicant.nil?
-      flash[:error] = t('applicants.login_error')
 
-      @applicant = Applicant.new
-
-      if /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.match?(params[:applicant_login_field])
+      if match_email?(params[:applicant_login_field])
         @applicant_login_email = params[:applicant_login_field]
-      elsif /\A[\d\s+]+\z/.match?(params[:applicant_login_field])
+      elsif match_phone?(params[:applicant_login_field])
         @applicant_login_phone = params[:applicant_login_field]
+      else
+        flash[:error] = t('applicants.login_input_error')
+        redirect_to applicant_login_path
+        return
       end
+
+      flash[:error] = t('applicants.login_error')
+      @applicant = Applicant.new
 
       render :new
       return
@@ -43,6 +47,14 @@ class ApplicantSessionsController < UserSessionsController
   end
 
 private
+
+  def match_email?(field)
+    /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.match?(field)
+  end
+
+  def match_phone?(field)
+    /\A[\d\s+]+\z/.match?(field)
+  end
 
   def login_applicant(applicant)
     session[:applicant_id] = applicant.id

--- a/app/controllers/applicant_sessions_controller.rb
+++ b/app/controllers/applicant_sessions_controller.rb
@@ -19,7 +19,13 @@ class ApplicantSessionsController < UserSessionsController
       flash[:error] = t('applicants.login_error')
 
       @applicant = Applicant.new
-      @applicant_login_field = params[:applicant_login_field]
+
+      if /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.match?(params[:applicant_login_field])
+        @applicant_login_email = params[:applicant_login_field]
+      elsif /\A[\d\s+]+\z/.match?(params[:applicant_login_field])
+        @applicant_login_phone = params[:applicant_login_field]
+      end
+
       render :new
       return
     end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -115,11 +115,19 @@ class Applicant < ApplicationRecord
   end
 
   class << self
+    def match_email?(field)
+      /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.match?(field)
+    end
+
+    def match_phone?(field)
+      /\A[\d\s+]+\z/.match?(field)
+    end
+
     def authenticate(field, password)
       # Check if email or phone number
-      if /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.match?(field)
+      if match_email?(field)
         applicant = where(disabled: false).find_by(email: field.downcase)
-      elsif /\A[\d\s+]+\z/.match?(field)
+      elsif match_phone?(field)
         applicant = where(disabled: false).find_by(phone: field)
       end
 
@@ -127,6 +135,7 @@ class Applicant < ApplicationRecord
                           BCrypt::Password.new(applicant.hashed_password) == password
     end
   end
+
 
   def lowest_priority_group(admission)
     job_applications.select { |application| application.job.admission == admission && application.withdrawn == false }.max_by(&:priority).job.group.id

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -115,8 +115,14 @@ class Applicant < ApplicationRecord
   end
 
   class << self
-    def authenticate(email, password)
-      applicant = where(disabled: false).find_by(email: email.downcase)
+    def authenticate(field, password)
+      # Check if email or phone number
+      if /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.match?(field)
+        applicant = where(disabled: false).find_by(email: field.downcase)
+      elsif /\A[\d\s+]+\z/.match?(field)
+        applicant = where(disabled: false).find_by(phone: field)
+      end
+
       return applicant if applicant &&
                           BCrypt::Password.new(applicant.hashed_password) == password
     end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -13,6 +13,7 @@ class Applicant < ApplicationRecord
   validates :email, :phone, uniqueness: true
 
   validates :email, email: true
+  validates :email, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
 
   validates :gdpr_checkbox, acceptance: true
 
@@ -115,19 +116,19 @@ class Applicant < ApplicationRecord
   end
 
   class << self
-    def match_email?(field)
+    def valid_email?(field)
       /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.match?(field)
     end
 
-    def match_phone?(field)
+    def valid_phone?(field)
       /\A[\d\s+]+\z/.match?(field)
     end
 
     def authenticate(field, password)
       # Check if email or phone number
-      if match_email?(field)
+      if valid_email?(field)
         applicant = where(disabled: false).find_by(email: field.downcase)
-      elsif match_phone?(field)
+      elsif valid_phone?(field)
         applicant = where(disabled: false).find_by(phone: field)
       end
 

--- a/app/views/applicant_sessions/_form.html.haml
+++ b/app/views/applicant_sessions/_form.html.haml
@@ -3,10 +3,10 @@
   = hidden_field_tag "redirect_to", html_escape(redirect_to) if local_assigns[:redirect_to]
 
   %p
-    != text_field_tag "applicant_login_email", html_escape(local_assigns[:applicant_login_email]),
+    != text_field_tag "applicant_login_field", html_escape(local_assigns[:applicant_login_field]),
       size: login_text_input_width,
       class: 'textfield',
-      placeholder: t("applicant_sessions.forms.login.applicant_login_email"),
+      placeholder: t("applicant_sessions.forms.login.applicant_login_field"),
       required: true
 
   %p

--- a/app/views/applicants/_form.html.haml
+++ b/app/views/applicants/_form.html.haml
@@ -6,11 +6,11 @@
         != form.input :firstname
         != form.input :surname
       .flex-row.wrap
-        != form.input :phone
+        != form.input :phone, input_html: { value: @applicant_login_phone }
         != form.input :campus_id, as: :select, collection: Campus.order(:name)
 
     = form.inputs name: t("applicants.forms.register.login_information") do
-      != form.input :email
+      != form.input :email, input_html: { value: @applicant_login_email }
       != form.input :password, input_html: {value: ""}
       != form.input :password_confirmation, input_html: {value: ""}
 

--- a/config/locales/views/applicant_sessions/en.yml
+++ b/config/locales/views/applicant_sessions/en.yml
@@ -6,5 +6,5 @@ en:
       login:
         heading: "Applicants"
         submit: "Login as applicant"
-        applicant_login_email: "E-mail"
+        applicant_login_field: "E-mail or phone number"
         forgot_password: "Forgotten your password?"

--- a/config/locales/views/applicant_sessions/no.yml
+++ b/config/locales/views/applicant_sessions/no.yml
@@ -6,5 +6,5 @@
       login:
         heading: "Søkere"
         submit: "Logg inn som søker"
-        applicant_login_field: "E-post eller telfonnummer"
+        applicant_login_field: "E-post eller telefonnummer"
         forgot_password: "Glemt passordet ditt?"

--- a/config/locales/views/applicant_sessions/no.yml
+++ b/config/locales/views/applicant_sessions/no.yml
@@ -6,5 +6,5 @@
       login:
         heading: "Søkere"
         submit: "Logg inn som søker"
-        applicant_login_email: "E-post"
+        applicant_login_field: "E-post eller telfonnummer"
         forgot_password: "Glemt passordet ditt?"

--- a/config/locales/views/applicants/en.yml
+++ b/config/locales/views/applicants/en.yml
@@ -14,6 +14,7 @@ en:
     update_error: "Your details were not updated. Se details below."
     login_success: "You are now logged in as %{name}."
     login_success_application_saved: "You are now logged in as %{name}, and your application was saved."
+    login_input_error: "You provided an invalid e-mail address or phone number."
     login_error: "Wrong combination of username and password."
     logout_success: "You are now logged out."
     will_be_logged_out_as_member: "By filling out the following form you will be logged out as a member."

--- a/config/locales/views/applicants/no.yml
+++ b/config/locales/views/applicants/no.yml
@@ -14,6 +14,7 @@
     update_error: "Dine detaljer ble ikke oppdatert. Se detaljer nedenfor."
     login_success: "Du er nå logget inn som %{name}."
     login_success_application_saved: "Du er nå logget inn som %{name}, og søknaden din er lagret."
+    login_input_error: "Du skrev en ugyldig e-post adresse eller telefonnummer."
     login_error: "Ugyldig kombinasjon av brukernavn og passord."
     logout_success: "Du er nå logget ut."
     will_be_logged_out_as_member: "Ved å fylle ut skjemaet under vil du bli logget ut som medlem."

--- a/config/locales/views/applicants/no.yml
+++ b/config/locales/views/applicants/no.yml
@@ -14,7 +14,7 @@
     update_error: "Dine detaljer ble ikke oppdatert. Se detaljer nedenfor."
     login_success: "Du er nå logget inn som %{name}."
     login_success_application_saved: "Du er nå logget inn som %{name}, og søknaden din er lagret."
-    login_input_error: "Du skrev en ugyldig e-post adresse eller telefonnummer."
+    login_input_error: "Du oppgav en ugyldig e-post adresse eller telefonnummer."
     login_error: "Ugyldig kombinasjon av brukernavn og passord."
     logout_success: "Du er nå logget ut."
     will_be_logged_out_as_member: "Ved å fylle ut skjemaet under vil du bli logget ut som medlem."

--- a/features/guest_applying_for_job.feature
+++ b/features/guest_applying_for_job.feature
@@ -14,7 +14,7 @@ Feature: Guest applying for jobs
         And I press "Apply for this job"
         Then I should see "Register or log in as an applicant to complete your application"
         When I fill in the following:
-            | applicant_login_email    | user@example.org |
+            | applicant_login_field    | user@example.org |
             | applicant_login_password | secret              |
         And I press "Login as applicant"
         Then I should be on user@example.org's applications page

--- a/spec/controllers/applicant_session_controller_spec.rb
+++ b/spec/controllers/applicant_session_controller_spec.rb
@@ -23,7 +23,7 @@ describe ApplicantSessionsController do
         post(
           :create,
           params: {
-            applicant_login_email: user.email,
+            applicant_login_field: user.email,
             applicant_login_password: 'password'
           }
         )
@@ -39,7 +39,7 @@ describe ApplicantSessionsController do
         post(
           :create,
           params: {
-            applicant_login_email: user.email,
+            applicant_login_field: user.email,
             applicant_login_password: 'password'
           },
           session: {
@@ -58,7 +58,7 @@ describe ApplicantSessionsController do
         post(
           :create,
           params: {
-            applicant_login_email: user.email,
+            applicant_login_field: user.email,
             applicant_login_password: 'invalid'
           }
         )


### PR DESCRIPTION
Adds this:
![image](https://github.com/Samfundet/Samfundet/assets/48588529/5aeff0b1-7637-4749-a81b-aa55f8e91116)
Will validate on both phone number and e-mail.

Useful because applicants have a tendency to forget which email they are registered with.