### PR TITLE
[Change] Enable phone number input on forgot password form

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -75,9 +75,15 @@ class ApplicantsController < ApplicationController
   def forgot_password; end
 
   def generate_forgot_password_email
-    @applicant = Applicant.find_by(email: params[:email])
+    # Check if email or phone number
+    if Applicant.valid_email?(params[:applicant_login_field])
+      @applicant = Applicant.find_by(email: params[:applicant_login_field].downcase)
+    elsif Applicant.valid_phone?(params[:applicant_login_field])
+      @applicant = Applicant.find_by(phone: params[:applicant_login_field])
+    end
+
     if !@applicant
-      flash[:error] = t('applicants.password_recovery.email_unknown')
+      flash[:error] = t('applicants.password_recovery.field_unknown')
     elsif !@applicant.can_recover_password?
       flash[:error] = t('applicants.password_recovery.limit_reached')
     elsif PasswordRecovery.create!(applicant_id: @applicant.id,
@@ -93,7 +99,7 @@ class ApplicantsController < ApplicationController
     else
       flash[:error] = t('applicants.password_recovery.error')
     end
-    redirect_to forgot_password_path
+    redirect_to applicant_login_path
   end
 
   def prepare_form

--- a/app/views/applicants/forgot_password.html.haml
+++ b/app/views/applicants/forgot_password.html.haml
@@ -1,15 +1,27 @@
-.section
-  %h2
-    = set_and_return_title t("applicants.password_recovery.forgot_password")
-  %p
-    = t("applicants.password_recovery.help_text")
-  %form{ action: generate_forgot_password_email_path, method: "post", class: "formtastic applicant"}
+- set_title t("user_sessions.new.title")
+
+%h1.text-Align=t("applicants.password_recovery.forgot_password")
+%p.text-Align=t("applicants.password_recovery.help_text")
+
+.login-form.applicant
+
+  = form_tag generate_forgot_password_email_path, method: :post, class: "custom-form", id: "applicant_forgot_password_form" do
     = hidden_field_tag :authenticity_token, form_authenticity_token
-    %fieldset{ class: "inputs" }
-      %ol
-        %li{ class: "string optional" }
-          %label Epost
-          %input{ type: "text", name: "email" }
-    %fieldset{ class: "buttons" }
-      %ol
-        %input{ type: "submit", value: t("applicant_sessions.forms.login.forgot_password") }
+
+    %p
+      != text_field_tag "applicant_login_field", html_escape(local_assigns[:applicant_login_field]),
+        size: login_text_input_width,
+        class: 'textfield',
+        placeholder: t("applicant_sessions.forms.login.applicant_login_field"),
+        required: true
+
+    %p
+      != submit_tag t("applicant_sessions.forms.login.recover_password")
+
+  %hr
+
+  .text-Align
+    %p=t("applicants.are_you_not_registered")
+    = link_to new_applicant_path do
+      .center.samf-button.plain
+        = t("applicants.register_as_an_applicant")

--- a/config/locales/views/applicant_sessions/en.yml
+++ b/config/locales/views/applicant_sessions/en.yml
@@ -8,3 +8,4 @@ en:
         submit: "Login as applicant"
         applicant_login_field: "E-mail or phone number"
         forgot_password: "Forgotten your password?"
+        recover_password: "Recover password"

--- a/config/locales/views/applicant_sessions/no.yml
+++ b/config/locales/views/applicant_sessions/no.yml
@@ -8,3 +8,4 @@
         submit: "Logg inn som søker"
         applicant_login_field: "E-post eller telefonnummer"
         forgot_password: "Glemt passordet ditt?"
+        recover_password: "Gjennopprett passord"

--- a/config/locales/views/applicants/en.yml
+++ b/config/locales/views/applicants/en.yml
@@ -40,7 +40,7 @@ en:
         heading: "Set a new password"
         submit: "Save new password"
     password_recovery:
-      email_unknown: "Unknown email, please try again."
+      field_unknown: "Unknown e-mail or phone number, please try again."
       limit_reached: "You have reached the limit for possible password recovery requests. If the problem persists, please send an email to mg-web@samfundet.no"
       success: "An email have been sendt to %{email} with instructions on how to proceed."
       error: "An error happened, the password recovery process has not been completed."
@@ -49,7 +49,7 @@ en:
       change_error: "Password has not been changed, see details below:"
       forgot_password: "Forgot password"
       new_password: "New password"
-      help_text: "Put your email in the field below to recieve an email with a link that can be used to give yourself a new password."
+      help_text: "Provide your e-mail or phone number below, and we will e-mail you a link which can be used to set a new password."
       email_subject: Reset password (samfundet.no)
       email_message: |
         Hi, %{name}
@@ -60,7 +60,7 @@ en:
 
         If clicking the link above does nothing, try to copy the URL and paste it into the address field of your web browser.
 
-        If you did not forget your password, please disregard this email.
+        If you did not forget your password, please disregard this e-mail.
 
         --
         samfundet.no/opptak

--- a/config/locales/views/applicants/no.yml
+++ b/config/locales/views/applicants/no.yml
@@ -40,7 +40,7 @@
         heading: "Sett et nytt passord"
         submit: "Lagre nytt passord"
     password_recovery:
-      email_unknown: "Ukjent epost, prøv igjen."
+      field_unknown: "Ukjent e-post eller telefonnummer, prøv igjen."
       limit_reached: "Du har oversteget grensen for mulige passordtilbakestillinger. Hvis problemet ikke er løst kan du sende en epost til mg-web@samfundet.no"
       success: "En epost har blitt sendt til %{email} med videre instrukser."
       error: "En feil har skjedd, passordbytte har ikke blitt fullført."
@@ -49,7 +49,7 @@
       change_error: "Passord ikke endret, se detaljer under:"
       forgot_password: "Glemt passord"
       new_password: "Nytt passord"
-      help_text: "Skriv inn eposten din i feltet under, så vil vi sende deg en epost med en lenke du kan bruke til å sette et nytt passord."
+      help_text: "Skriv inn e-post eller telefonnummer i feltet under, så vil vi sende deg en e-post med en lenke du kan bruke til å sette et nytt passord."
       email_subject: Registrer nytt passord (samfundet.no)
       email_message: |
         Hei, %{name}
@@ -60,7 +60,7 @@
 
         Hvis det ikke fungerer å trykke på lenken, kan du kopiere adressen og lime den inn i adressefeltet til nettleseren din.
 
-        Har du ikke glemt passordet ditt, kan du bare se bort fra denne eposten.
+        Har du ikke glemt passordet ditt, kan du bare se bort fra denne e-posten.
 
         --
         samfundet.no/opptak

--- a/features/step_definitions/applicants_steps.rb
+++ b/features/step_definitions/applicants_steps.rb
@@ -27,14 +27,14 @@ Given /^I am logged in as an applicant with email "([^\"]*)"$/ do |email|
   step "I am registered with email \"#{email}\" and password \"secret\""
 
   visit applicants_login_path
-  fill_in "applicant_login_email", with: email
+  fill_in "applicant_login_field", with: email
   fill_in "applicant_login_password", with: "secret"
   click_button("Login as applicant")
 end
 
 When /^I log in as an applicant with email "([^\"]*)" and password "([^\"]*)"$/ do |email, password|
   # assumes you are on the login page
-  fill_in "applicant_login_email", with: email
+  fill_in "applicant_login_field", with: email
   fill_in "applicant_login_password", with: password
   click_button("Login as applicant")
 end


### PR DESCRIPTION
Adds support for phone numbers on forgot password form.

Also redesigns from this:

![image](https://github.com/Samfundet/Samfundet/assets/48588529/99887945-6457-4fa6-9215-35b243053f1e)


To this:

![image](https://github.com/Samfundet/Samfundet/assets/48588529/86b06db2-8850-4544-a0b7-10ccaa77dfaa)
