### PR TITLE
[Bugfix] Change redirect after password reset to applicant login page

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -120,7 +120,7 @@ class ApplicantsController < ApplicationController
         PasswordRecovery.find_by(applicant_id: @applicant.id).destroy
         flash[:success] = t('applicants.password_recovery.change_success')
 
-        redirect_to login_path
+        redirect_to applicant_login_path
       else
         prepare_form
         flash[:error] = t('applicants.password_recovery.change_error')


### PR DESCRIPTION
The redirect was wrong after applicants reset their password.
This can cause a lot of confusion.