### PR TITLE
[Bugfix] Force hash and email to be present on reset password form

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -96,18 +96,18 @@ class ApplicantsController < ApplicationController
     redirect_to forgot_password_path
   end
 
-  def prepare_form
+  def prepare_reset_password_form
     @hash = params[:hash]
     @email = params[:email]
   end
 
   def reset_password
     @applicant = Applicant.find_by(email: params[:email])
-    if !@applicant || !@applicant.check_hash(params[:hash])
+    if !@applicant || !@applicant.check_hash(params[:hash]) || params[:hash] == nil
       flash[:error] = t('applicants.password_recovery.hash_error')
       @applicant = nil
     else
-      prepare_form
+      prepare_reset_password_form
     end
   end
 
@@ -122,13 +122,13 @@ class ApplicantsController < ApplicationController
 
         redirect_to login_path
       else
-        prepare_form
+        prepare_reset_password_form
         flash[:error] = t('applicants.password_recovery.change_error')
         render :reset_password
       end
     else
-      prepare_form
-      flash[:error] = t('applicants.password_recovery.change_error')
+      flash[:error] = t('applicants.password_recovery.hash_error')
+      @applicant = nil
       render :reset_password
     end
   end

--- a/app/views/applicants/reset_password.html.haml
+++ b/app/views/applicants/reset_password.html.haml
@@ -1,5 +1,5 @@
 - set_title t("applicants.password_recovery.new_password")
 
 .section
-  - if @applicant
+  - if @applicant && @hash && @email
     = render 'form_reset_password', applicant: @applicant, hash: @hash, email: @email


### PR DESCRIPTION
### Reproduce bug:

1. Go to the forgot password form, and type in a valid applicant e-mail address
2. Click the link in the generated e-mail. Set a new password
3. Click the back button on the browser. Try to set a new password again

This should not be possible. This PR fixes this bug.

- The reset password link would be possible to re-use at a later time, if the page is cached on the browser. Now you need to have an email and a valid hash present in order to load the reset password page

- Gives instant feedback to the user if the link is invalid.

- Rename method "prepare form" into prepare "reset password form"