### PR TITLE
[Change] Add restriction for editing status & priority, except for Admission Admin

### DIFF
--- a/app/controllers/admissions_admin/interviews_controller.rb
+++ b/app/controllers/admissions_admin/interviews_controller.rb
@@ -47,6 +47,10 @@ class AdmissionsAdmin::InterviewsController < AdmissionsAdmin::BaseController
     end
 
     if params[:interview][:applicant_status]
+      if !@interview.can_set_status? && !(can? :manage, Admission)
+        ## Backend validations
+        return
+      end
       @interview.applicant_status = params[:interview][:applicant_status]
 
       # Automatically set priority (if not set) for convenience
@@ -60,9 +64,8 @@ class AdmissionsAdmin::InterviewsController < AdmissionsAdmin::BaseController
 
     end
 
-    if @interview.past_set_priority_deadline? && @interview.priority_changed?
-      raise t('interviews.cannot_set_priority_past_deadline')
-    else
+    if !(@interview.past_set_priority_deadline? && @interview.priority_changed?) || (can? :manage, Admission)
+      # Backend validations
       @interview.save!
 
       @interview_warning = nil

--- a/app/controllers/admissions_admin/jobs_controller.rb
+++ b/app/controllers/admissions_admin/jobs_controller.rb
@@ -35,6 +35,7 @@ class AdmissionsAdmin::JobsController < AdmissionsAdmin::BaseController
     @groupings = [@job.unprocessed_applications]
     @group = Group.find(params[:group_id])
     @admission = Admission.find(params[:admission_id])
+
     render partial: 'jobs_show'
   end
 

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -100,6 +100,10 @@ class Interview < ApplicationRecord
   def past_set_priority_deadline?
     job_application.job.admission.admin_priority_deadline < Time.current
   end
+
+  def can_set_status?
+    past_set_priority_deadline? && priority?
+  end
 end
 
 # == Schema Information

--- a/app/views/admissions_admin/job_applications/show.html.haml
+++ b/app/views/admissions_admin/job_applications/show.html.haml
@@ -136,14 +136,14 @@
             %td
               = semantic_form_for([:admissions_admin, admission, group, job, job_application, interview = job_application.find_or_create_interview], namespace: "interview_#{interview.id}", html: {class: "test custom-form"}) do |form|
                 = form.inputs do
-                  != form.input :priority, name: "priority", as: :select, label: false, required: true, value: interview.priority, collection: interview.priorities.invert.sort, input_html: { id: "interview_#{job_application.id}_priority", disabled: interview.past_set_priority_deadline? }
+                  != form.input :priority, name: "priority", as: :select, label: false, required: true, value: interview.priority, collection: interview.priorities.invert.sort, input_html: { id: "interview_#{job_application.id}_priority", disabled: interview.past_set_priority_deadline? && !(can? :manage, Admission) }
                 %span{ class: "status" }
                 = form.actions do
                   != form.action :submit, button_html: { class: "interview_save", value: t('interviews.save_interview_status') }
             %td
               = semantic_form_for([:admissions_admin, admission, group, job, job_application, interview = job_application.find_or_create_interview], namespace: "interview_#{interview.id}", html: {class: "test custom-form"}) do |form|
                 = form.inputs do
-                  != form.input :applicant_status, name: "applicant_status", as: :select, label: false, required: true, value: interview.applicant_status, collection: interview.applicant_statuses.invert, input_html: { id: "interview_#{job_application.id}_applicant_status"}
+                  != form.input :applicant_status, name: "applicant_status", as: :select, label: false, required: true, value: interview.applicant_status, collection: interview.applicant_statuses.invert, input_html: { id: "interview_#{job_application.id}_applicant_status", disabled: !interview.can_set_status? && !can?(:manage, Admission) }
                 = form.actions do
                   != form.action :submit, button_html: { class: "interview_save", value: t('interviews.save_interview_status') }
                 %span{ class: "status" }

--- a/app/views/admissions_admin/jobs/_jobs_show.html.haml
+++ b/app/views/admissions_admin/jobs/_jobs_show.html.haml
@@ -97,14 +97,14 @@
           %td
             = semantic_form_for([:admissions_admin, @admission, @group, job_application.job, job_application, interview = job_application.find_or_create_interview], namespace: "interview_#{interview.id}", html: {class: "test custom-form"}) do |form|
               = form.inputs do
-                != form.input :priority, name: "priority", as: :select, label: false, required: true, value: interview.priority, collection: interview.priorities.invert.sort, input_html: { id: "interview_#{job_application.id}_priority", disabled: interview.past_set_priority_deadline? }
+                != form.input :priority, name: "priority", as: :select, label: false, required: true, value: interview.priority, collection: interview.priorities.invert.sort, input_html: { id: "interview_#{job_application.id}_priority", disabled: interview.past_set_priority_deadline? && !(can? :manage, Admission) }
               %span{ class: "status" }
               = form.actions do
                 != form.action :submit, button_html: { class: "interview_save", value: t('interviews.save_interview_status') }
           %td
             = semantic_form_for([:admissions_admin, @admission, @group, job_application.job, job_application, interview = job_application.find_or_create_interview], namespace: "interview_#{interview.id}", html: {class: "test custom-form"}) do |form|
               = form.inputs do
-                != form.input :applicant_status, name: "applicant_status", as: :select, label: false, required: true, value: interview.applicant_status, collection: interview.applicant_statuses.invert, input_html: { id: "interview_#{job_application.id}_applicant_status"}
+                != form.input :applicant_status, name: "applicant_status", as: :select, label: false, required: true, value: interview.applicant_status, collection: interview.applicant_statuses.invert, input_html: { id: "interview_#{job_application.id}_applicant_status", disabled: !interview.can_set_status? && !can?(:manage, Admission) }
               = form.actions do
                 != form.action :submit, button_html: { class: "interview_save", value: t('interviews.save_interview_status') }
               %span{ class: "status" }


### PR DESCRIPTION
_FYI: This functionality is agreed upon between me and Ingvild (Admission responsible)_

- Administrator of admission can always edit priority and status of an applicant, no matter if priority deadline is past or not. Mainly to correct stuff if someone f**cks something up
- Admission responsible for groups can ONLY set priority before the priority deadline, and ONLY status after priority deadline. There is also backend validations for this to check if this is correct
- The purpose of this change is to ensure correctness of data and overview for statistics and data that are used during admission