### PR TITLE
[Bugfix] Add proper error message when user does not have access to a page + contributors

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -48,3 +48,5 @@ Johanne Dybevik
 Oscar Aleksander Halvorsen
 Mathias Haakon Aas
 Mari Hval
+Simen Myrrusten
+Robin Espinosa

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -72,13 +72,22 @@ class ApplicationController < ActionController::Base
     if request.xhr?
       render nothing: true, status: 401
     else
-      flash[:error] = t('common.log_in_to_view_page')
-      if request.get? # Regular GET
-        redirect_to login_path(redirect_to: request.path)
-      elsif request.referer.nil?
+      if logged_in?
+        flash[:error] = t('common.no_access')
+
+        if current_user.roles.count > 0
+          flash[:message] = t('common.group_leader_access')
+        end
         redirect_to root_path
       else
-        redirect_to login_path(redirect_to: request_referer_if_on_current_domain)
+        flash[:error] = t('common.log_in_to_view_page')
+        if request.get? # Regular GET
+          redirect_to login_path(redirect_to: request.path)
+        elsif request.referer.nil?
+          redirect_to root_path
+        else
+          redirect_to login_path(redirect_to: request_referer_if_on_current_domain)
+        end
       end
     end
   end

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -17,6 +17,8 @@ en:
     down: "Down"
     please_select: "Please select"
     log_in_to_view_page: "You have to log in to view this page."
+    no_access: "You do not have access to view this page."
+    group_leader_access: "If you think this is wrong please contact your group leader."
   time:
     last_updated: "Last updated"
     created: "Created"

--- a/config/locales/defaults/no.yml
+++ b/config/locales/defaults/no.yml
@@ -17,6 +17,8 @@
     down: "Ned"
     please_select: "Vennligst velg"
     log_in_to_view_page: "Du må logge inn for å få tilgang til denne siden."
+    no_access: "Du har ikke tilgang til å vise denne siden."
+    group_leader_access: "Om du mener dette er feil vennligst kontakt din gjengsjef."
   time:
     last_updated: "Sist oppdatert"
     created: "Opprettet"


### PR DESCRIPTION
If the user does not have privilege to access a page they are asked to log in again, even though they are already logged in.

**To reproduce:**

1. Log in with a lim_web user on one window
2. Open a private window and log in with another user on that window. This user must have a role with added privileges, i.e. admissions
3. Go to an admission page on the private window
4. With the lim_web user, remove the role with the privileges of the other user.
5. Refresh the private window.You are asked to log in again