### PR TITLE
[Bugfix] Fix weird CanCan bug not authorizing show_unprocessed correctly in controller

### DIFF
--- a/app/controllers/admissions_admin/jobs_controller.rb
+++ b/app/controllers/admissions_admin/jobs_controller.rb
@@ -32,6 +32,11 @@ class AdmissionsAdmin::JobsController < AdmissionsAdmin::BaseController
 
   def show_unprocessed
     @job = Job.find(params[:job_id])
+    if !can?(:show_unprocessed, @job)
+      permission_denied
+      return
+    end
+
     @groupings = [@job.unprocessed_applications]
     @group = Group.find(params[:group_id])
     @admission = Admission.find(params[:admission_id])


### PR DESCRIPTION
This is a weird bug that allows anyone with the "Opptaksansvarlig" role to view all the unprocessed applications in the organization, as long as they have the URL.

It seems like there is a weird bug with the CanCan gem, and it makes custom actions in controllers not authorize correctly, even though permissions are set in abailities.rb. Checking manually in the controller is a quick workaround for the longevity of this project.

Try reproducing by going into a job page with applicants/interviews, adding /show_unprocessed to the URL and copy this URL. Now log in with another "Opptaksansvarlig" user, from a different group. Paste the URL, and they will see the applicants.