### PR TITLE
[Feature] Add applicant E-mail verification

### DIFF
--- a/app/helpers/applicant_verification_helper.rb
+++ b/app/helpers/applicant_verification_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ApplicantVerificationHelper
+  def email_verification_link(args = {})
+    email = args[:email]
+    applicant_id = args[:applicant_id]
+    verification_hash = args[:verification_hash]
+
+    if email.nil? || applicant_id.nil? || verification_hash.nil?
+      raise 'Email, appicantId or verification_hash not supplied.'
+    end
+
+    verify_email_url(email: email, applicant: applicant_id, hash: verification_hash)
+  end
+end

--- a/app/mailers/verify_email_applicant_mailer.rb
+++ b/app/mailers/verify_email_applicant_mailer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class VerifyEmailApplicantMailer < ActionMailer::Base
+  helper :applicant_verification
+
+  default from: %("MG::Web" <mg-web@samfundet.no>),
+          reply_to: 'mg-web@samfundet.no'
+
+  def send_applicant_email_verification(applicant)
+    @new_verification_hash_value = applicant.create_email_verification_hash
+    existing_verification_hash = EmailVerification.find_by(applicant_id: applicant.id)
+
+    if !existing_verification_hash
+      EmailVerification.create!(applicant_id: applicant.id,
+                                    verification_hash: @new_verification_hash_value)
+    else
+      existing_verification_hash.verification_hash = @new_verification_hash_value
+      existing_verification_hash.count += 1
+      existing_verification_hash.save!
+    end
+
+    @applicant = applicant
+    mail(to: applicant.email, subject: t('applicants.email_verification.email_subject'))
+  end
+end

--- a/app/models/email_verification.rb
+++ b/app/models/email_verification.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class EmailVerification < ApplicationRecord
+  # Dummy model to get db fetching to work
+  belongs_to :applicant, class_name: 'Applicant'
+end
+
+# == Schema Information
+#
+# Table name: email_verifications
+#
+#  id                 :bigint           not null, primary key
+#  verification_hash  :string           not null
+#  count              :integer          not null, default: 1
+#  applicant_id       :integer          not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null

--- a/app/views/applicants/_form.html.haml
+++ b/app/views/applicants/_form.html.haml
@@ -16,7 +16,7 @@
 
     = form.inputs name: t("applicants.forms.register.extra_information") do
       != form.input :interested_other_positions, as: :select, hint: t("applicants.interested_other_positions_hint")
-      != form.input :gdpr_checkbox, as: :boolean, label: raw(t("applicants.forms.register.gdpr_checkbox", en_url:'/en/information/privacy', no_url: '/informasjon/personvern'))
+      != form.input :gdpr_checkbox, as: :boolean, required: true, label: raw(t("applicants.forms.register.gdpr_checkbox", en_url:'/en/information/privacy', no_url: '/informasjon/personvern'))
 
     = form.actions do
       != submit_tag t("applicants.forms.register.submit")

--- a/app/views/verify_email_applicant_mailer/send_applicant_email_verification.text.haml
+++ b/app/views/verify_email_applicant_mailer/send_applicant_email_verification.text.haml
@@ -1,0 +1,8 @@
+= t('applicants.email_verification.email_message',
+    firstname: @applicant.firstname,
+    name: @applicant.full_name,
+    phone: @applicant.phone,
+    email: @applicant.email,
+    verification_link: email_verification_link(email: @applicant.email,
+                                              applicant_id: @applicant.id,
+                                              verification_hash: @new_verification_hash_value)).html_safe

--- a/config/locales/routes/i18n-routes.yml
+++ b/config/locales/routes/i18n-routes.yml
@@ -22,6 +22,7 @@
     admissions_admin: opptak-administrasjon
     forgot_password: glemt-passord
     reset_password: tilbakestill-passord
+    email_verification: bekreft-epost
     entry: innlegg
     entries: innlegg
     category: kategori

--- a/config/locales/views/applicants/en.yml
+++ b/config/locales/views/applicants/en.yml
@@ -63,4 +63,32 @@ en:
         If you did not forget your password, please disregard this e-mail.
 
         --
-        samfundet.no/opptak
+        For more information about this semester's admission, go to:
+        https://samfundet.no/en/admissions
+    email_verification:
+      login_email_unverified: "The E-mail address of %{name} is not verified. Please verify this e-mail address first."
+      verification_sent: "Verification e-mail sent to %{email}."
+      verification_link_invalid: "The verification link provided is invalid."
+      verification_success: "The E-mail address of %{name} was successfully verified. You can now log in as applicant."
+      too_many: "Too many verification e-mails sent the last hour. Try again later."
+      email_error: "An error has occurred. Verification email was not sent."
+      email_subject: "We are delighted to see you apply for Samfundet!"
+      email_message: |
+        Hey %{firstname},
+
+        We are delighted to see you wanting to apply for Samfundet!
+
+        The following personal details have been registered on your account:
+
+        Name: %{name}
+        Phone number: %{phone}
+        E-mail: %{email}
+
+        If this info is incorrect, please send an e-mail to mg-web@samfundet.no
+
+        To continue registration, please follow the link below. The link is valid for 60 minutes:
+        %{verification_link}
+
+        --
+        For more information about this semester's admission, go to:
+        https://samfundet.no/en/admissions

--- a/config/locales/views/applicants/no.yml
+++ b/config/locales/views/applicants/no.yml
@@ -63,4 +63,32 @@
         Har du ikke glemt passordet ditt, kan du bare se bort fra denne e-posten.
 
         --
-        samfundet.no/opptak
+        For mer informasjon om semesterets opptak, gå til:
+        https://samfundet.no/opptak
+    email_verification:
+      login_email_unverified: "E-post knyttet til %{name} er ikke bekreftet. Vennligst bekreft e-post adressen først."
+      verification_sent: "E-post bekreftelse er sendt til %{email}"
+      verification_link_invalid: "Bekreftelseslenken er ugyldig."
+      verification_success: "E-post knyttet til %{name} ble bekreftet. Du kan nå logge inn som søker."
+      too_many: "For mange bekreftelsemail sendt den siste timen. Prøv igjen senere."
+      email_error: "En feil har oppstått. E-post bekreftelse ble ikke sendt."
+      email_subject: "Så kult at du vil søke Samfundet!"
+      email_message: |
+        Hei %{firstname},
+
+        Så kult at du vil søke Samfundet!
+
+        Du er blitt registrert med følgende personalia:
+
+        Navn: %{name}
+        Telefon: %{phone}
+        E-post: %{email}
+
+        Om dette er feil, vennligst send en mail til mg-web@samfundet.no
+
+        For å fortsette registreringen, vennligst følg lenken nedenfor. Den er gyldig i 60 minutter:
+        %{verification_link}
+
+        --
+        For mer informasjon om Samfundets opptak, gå til:
+        https://samfundet.no/opptak

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,6 +106,7 @@ Rails.application.routes.draw do
       get "forgot_password", to: "applicants#forgot_password"
       post "generate_forgot_password_email", to: "applicants#generate_forgot_password_email"
       get "reset_password", to: "applicants#reset_password"
+      get "verify_email", to: "applicants#verify_email"
       get "search", to: "applicants#search", as: :applicant_search
     end
 

--- a/db/migrate/20230709174101_add_verified_to_applicants.rb
+++ b/db/migrate/20230709174101_add_verified_to_applicants.rb
@@ -1,0 +1,5 @@
+class AddVerifiedToApplicants < ActiveRecord::Migration[5.2]
+  def change
+    add_column :applicants, :verified, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20230806185604_create_email_verifications.rb
+++ b/db/migrate/20230806185604_create_email_verifications.rb
@@ -1,0 +1,12 @@
+class CreateEmailVerifications < ActiveRecord::Migration[5.2]
+  def change
+    create_table :email_verifications do |t|
+      t.string :verification_hash, null: false
+      t.integer :count, default: 1, null: false
+      t.integer :applicant_id, null: false
+
+      t.timestamps
+    end
+    add_foreign_key :email_verifications, :applicants, column: :applicant_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_20_212858) do
+ActiveRecord::Schema.define(version: 2023_08_06_185604) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2022_12_20_212858) do
     t.boolean "interested_other_positions"
     t.boolean "disabled", default: false
     t.integer "campus_id"
+    t.boolean "verified", default: false, null: false
   end
 
   create_table "areas", force: :cascade do |t|
@@ -174,6 +175,14 @@ ActiveRecord::Schema.define(version: 2022_12_20_212858) do
     t.string "file_content_type"
     t.integer "file_file_size"
     t.datetime "file_updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "email_verifications", force: :cascade do |t|
+    t.string "verification_hash", null: false
+    t.integer "count", default: 1, null: false
+    t.integer "applicant_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -523,6 +532,7 @@ ActiveRecord::Schema.define(version: 2022_12_20_212858) do
   end
 
   add_foreign_key "blogs", "images", name: "blog_articles_image_id_fk"
+  add_foreign_key "email_verifications", "applicants"
   add_foreign_key "events", "images", name: "events_image_id_fk"
   add_foreign_key "groups", "group_types", name: "groups_group_type_id_fk"
   add_foreign_key "images_tags", "images", name: "images_tags_image_id_fk"


### PR DESCRIPTION
- Upon registering as applicant, the applicants will have a verification e-mail sent to them
- When logging in, there will be a verification check
- If logging in and your account is unverified, a new verification e-mail will be sent (heavily inspired by UKA lol)
- Only one verification link is valid at a time
- The verification link is valid for one hour. If too many verification links are sent within one hour, the user will be blocked from receiving more