### PR TITLE
[Bugfix] Fix rule for showing kitchen open text

### DIFF
--- a/app/controllers/sulten/lyche_controller.rb
+++ b/app/controllers/sulten/lyche_controller.rb
@@ -6,6 +6,7 @@
 class Sulten::LycheController < Sulten::BaseController
   skip_authorization_check
   layout 'lyche'
+  before_action :check_food_open, only: %i[index reservation]
 
   def index
     # Check if in closed period
@@ -25,13 +26,15 @@ class Sulten::LycheController < Sulten::BaseController
     end
   end
 
-  def reservation
+  def check_food_open
     food_open_date = Date.parse('17.08.2023')
     @food_closed = false
     if food_open_date > Time.now
       @food_closed = true
     end
+  end
 
+  def reservation
     @closed_periods = Sulten::ClosedPeriod.current_and_future_closed_times.sort_by(&:closed_from)
     unless @closed_periods.empty?
       # Show only if less than 60 days in future

--- a/app/views/sulten/lyche/_status_box.html.haml
+++ b/app/views/sulten/lyche/_status_box.html.haml
@@ -25,7 +25,7 @@
           %td= t("sulten.lyche.status_box.closed_period")
           %td= l(@closed.closed_from, format: :short_date) + " - " + l(@closed.closed_to, format: :short_date)
 
-  - if @closed.nil?
+  - if @food_closed
     %p{style: "color: white; text-align: center; font-size: 1em;"}
       %i{style: "font-weight: bold;"}
         ="NB:"


### PR DESCRIPTION
The text does not show if Lyche is not open