### PR TITLE
Add line that makes verification email field lowercase

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -14,6 +14,7 @@ class ApplicantsController < ApplicationController
 
   def create
     params[:applicant][:email].downcase!
+    params[:applicant][:email_confirmation].downcase!
     @applicant = Applicant.new(applicant_params)
 
     if @applicant.save


### PR DESCRIPTION
People who use uppercase letters in their email verification field now will get an error. This is because email field is made lowercase while the verification email field is kept as original