### PR TITLE
Lyche: Show all future closed periods on reservation page

### DIFF
--- a/app/controllers/sulten/lyche_controller.rb
+++ b/app/controllers/sulten/lyche_controller.rb
@@ -36,12 +36,9 @@ class Sulten::LycheController < Sulten::BaseController
 
   def reservation
     @closed_periods = Sulten::ClosedPeriod.current_and_future_closed_times.sort_by(&:closed_from)
-    unless @closed_periods.empty?
-      # Show only if less than 60 days in future
-      if (@closed_periods.first.closed_from - Time.now) < 60.days
-        @closed_periods = [@closed_periods.first]
-      else
-        @closed_periods = []
+    @closed_periods.delete_if do |c|
+      if (c.closed_from - Time.now) > 60.days
+        true
       end
     end
     @reservation = Sulten::Reservation.new

--- a/app/views/sulten/lyche/reservation.html.haml
+++ b/app/views/sulten/lyche/reservation.html.haml
@@ -13,10 +13,10 @@
     = mail_to "lyche@samfundet.no"
     %br
     %br
-    - @closed_periods.each do |c|
+    - unless @closed_periods.empty?
       %i
-        = t("sulten.lyche.reservation.closed_period") + " " + l(c.closed_from, format: :short_date) + " - " + l(c.closed_to, format: :short_date)
-      %br
+        = t("sulten.lyche.reservation.closed_period") + " "
+        = @closed_periods.map{ |c| l(c.closed_from, format: :short_date) + "–" + l(c.closed_to, format: :short_date)}.join(', ')
 
   - if @must_be_in_future
     = semantic_form_for @reservation, :html => { :class => "custom-form lyche_form"} do |f|


### PR DESCRIPTION
Only shows closed periods starting within 60 days from now. Looks like this:

<img width="676" alt="image" src="https://github.com/Samfundet/Samfundet/assets/16273164/c78cf532-e7dd-4ba4-9139-9719128bbb65">
