### PR TITLE
Hide recruitment video wrapper if empty

### DIFF
--- a/app/views/admissions/_promo.html.haml
+++ b/app/views/admissions/_promo.html.haml
@@ -1,5 +1,5 @@
-.youtube-wrapper
-  - if not @open_admissions.first.promo_video.empty?
+- if not @open_admissions.first.promo_video.empty?
+  .youtube-wrapper
     %iframe.youtube-embed{ src: @open_admissions.first.promo_video, frameborder: 0, allowfullscreen: true }
 
 %div.text-Align.pt-3


### PR DESCRIPTION
There's currently a huge blank space where the video goes if a recruitment has no video