### PR TITLE
Custom groups for admissions

### DIFF
--- a/app/controllers/admissions_admin/admissions_controller.rb
+++ b/app/controllers/admissions_admin/admissions_controller.rb
@@ -224,7 +224,7 @@ protected
   end
 
   def admission_params
-    params.require(:admission).permit(:title, :shown_from, :shown_application_deadline, :actual_application_deadline, :user_priority_deadline, :admin_priority_deadline, :groups_with_separate_admission, :promo_video)
+    params.require(:admission).permit(:title, :shown_from, :shown_application_deadline, :actual_application_deadline, :user_priority_deadline, :admin_priority_deadline, :groups_with_separate_admission, :promo_video, :customized_groups)
   end
 
 private

--- a/app/controllers/admissions_admin/jobs_controller.rb
+++ b/app/controllers/admissions_admin/jobs_controller.rb
@@ -81,7 +81,9 @@ private
       :default_motivation_text_no,
       :default_motivation_text_en,
       :is_officer,
-      :tag_titles
+      :tag_titles,
+      :custom_group,
+      :custom_group_type
     )
   end
 

--- a/app/models/admission.rb
+++ b/app/models/admission.rb
@@ -118,17 +118,17 @@ class Admission < ApplicationRecord
   end
 
   def custom_group_types
-    jobs.map { |job| job.custom_group_type }.to_set.sort_by {|s| s="" ?  "zzz" : s}
+    jobs.map { |job| job.custom_group_type }.to_set.sort_by { |s| s=='' ?  'zzz' : s }
   end
 
   def custom_group(group_type)
     jobs.filter { |job| job.custom_group_type == group_type }
       .map(&:custom_group)
-      .to_set.sort_by {|s| s=="" ? "zzz" : s}
+      .to_set.sort_by { |s| s=='' ? 'zzz' : s }
   end
 
   def jobs_in_custom_group(group)
-    jobs.select {|job| job.custom_group==group}
+    jobs.select { |job| job.custom_group==group }
   end
 
   def appliable?

--- a/app/models/admission.rb
+++ b/app/models/admission.rb
@@ -117,6 +117,20 @@ class Admission < ApplicationRecord
     Admission.active.any?
   end
 
+  def custom_group_types
+    jobs.map { |job| job.custom_group_type }.to_set.sort_by {|s| s="" ?  "zzz" : s}
+  end
+
+  def custom_group(group_type)
+    jobs.filter { |job| job.custom_group_type == group_type }
+      .map(&:custom_group)
+      .to_set.sort_by {|s| s=="" ? "zzz" : s}
+  end
+
+  def jobs_in_custom_group(group)
+    jobs.select {|job| job.custom_group==group}
+  end
+
   def appliable?
     (actual_application_deadline > Time.current) && (shown_from < Time.current)
   end
@@ -144,6 +158,7 @@ class Admission < ApplicationRecord
     end
   end
 end
+
 
 # == Schema Information
 #

--- a/app/views/admissions/_jobs.html.haml
+++ b/app/views/admissions/_jobs.html.haml
@@ -1,14 +1,31 @@
-- admission.group_types.sort_by(&:description).each do |group_type|
-  .samf-container.white.mb-3.pb-2.br-3.bxs
-    %h2.text-Align.p-1.bg-red.title.white= group_type.description
-    - group_type.groups.each do |group|
-      - group.jobs_in_admission(admission).sort_by(&:title).each do |job|
-        .m-3.pb-2.jobs{ id: "#{admission.to_param}/#{group.to_param}"}
-          %span.bullet{ class: job.is_officer ? "officer_position" : "non_officer_position"}
-          .flex-row.space-around.jobRow
-            %a{href: job_path(job), style:"flex-basis: 30%"}
-              = truncate job.title, length: 40
-            %div{style:"flex-basis: 30%;"}
-              = group_link group, abbreviate_treshold: 20
-            %div.description{style:"flex-basis: 30%;"}
-              #{job.teaser.first(75)}
+- if admission.customized_groups
+  - admission.custom_group_types.each do |group_type|
+    .samf-container.white.mb-3.pb-2.br-3.bxs
+      %h2.text-Align.p-1.bg-red.title.white= group_type=="" ? t('admissions.other_groups_with_admissions') : group_type
+      - admission.custom_group(group_type).each do |group|
+        - admission.jobs_in_custom_group(group).sort_by(&:group).each do |job|
+          .m-3.pb-2.jobs{ id: "#{admission.to_param}/#{group.to_param}"}
+            %span.bullet{ class: job.is_officer ? "officer_position" : "non_officer_position"}
+            .flex-row.space-around.jobRow
+              %a{href: job_path(job), style:"flex-basis: 30%"}
+                = truncate job.title, length: 40
+              %div{style:"flex-basis: 30%;"}
+                = link_to job.group.page do
+                  = job.group.name + (group=="" ? "" : " - " +  group)
+              %div.description{style:"flex-basis: 30%;"}
+                #{job.teaser.first(75)}
+- else
+  - admission.group_types.sort_by(&:description).each do |group_type|
+    .samf-container.white.mb-3.pb-2.br-3.bxs
+      %h2.text-Align.p-1.bg-red.title.white= group_type.description
+      - group_type.groups.each do |group|
+        - group.jobs_in_admission(admission).sort_by(&:title).each do |job|
+          .m-3.pb-2.jobs{ id: "#{admission.to_param}/#{group.to_param}"}
+            %span.bullet{ class: job.is_officer ? "officer_position" : "non_officer_position"}
+            .flex-row.space-around.jobRow
+              %a{href: job_path(job), style:"flex-basis: 30%"}
+                = truncate job.title, length: 40
+              %div{style:"flex-basis: 30%;"}
+                = group_link group, abbreviate_treshold: 20
+              %div.description{style:"flex-basis: 30%;"}
+                #{job.teaser.first(75)}

--- a/app/views/admissions_admin/admissions/_form.html.haml
+++ b/app/views/admissions_admin/admissions/_form.html.haml
@@ -30,5 +30,7 @@
                   as: :text, hint: t('common.markdown_hint').html_safe
     != form.input :promo_video,
                   as: :string, hint: ("Promo video må legges ut som en embedded link. Bruksanvising på hvordan det gjøres kan du finne <a href='https://support.google.com/youtube/answer/171780?hl=en' target=blank>her</a>").html_safe
+    != form.input :customized_groups, as: :boolean
+
   = form.actions do
     != form.action :submit

--- a/app/views/admissions_admin/jobs/_form.html.haml
+++ b/app/views/admissions_admin/jobs/_form.html.haml
@@ -14,6 +14,8 @@
     .flex-row
       != form.input :default_motivation_text_no, as: :text
       != form.input :default_motivation_text_en, as: :text
+    != form.input :custom_group_type, :placeholder => t('jobs.only_customized_admission')
+    != form.input :custom_group, :placeholder => t('jobs.only_customized_admission')
     != form.input :is_officer, as: :boolean
     != form.input :tag_titles, as: :string, :placeholder => t('jobs.create_tags_example')
   = form.actions do

--- a/config/locales/models/admission/en.yml
+++ b/config/locales/models/admission/en.yml
@@ -20,3 +20,4 @@ en:
         user_priority_deadline: Priority deadline for applicants
         admin_priority_deadline: Priority deadline for groups
         groups_with_separate_admission: Groups with separate admission
+        customized_groups: Custom groups

--- a/config/locales/models/admission/no.yml
+++ b/config/locales/models/admission/no.yml
@@ -1,4 +1,4 @@
-'no':
+"no":
   helpers:
     models:
       admission:
@@ -20,3 +20,4 @@
         user_priority_deadline: Omprioriteringsfrist for søker
         admin_priority_deadline: Omprioriteringsfrist for gjenger
         groups_with_separate_admission: Gjenger med separat opptak
+        customized_groups: Egendefinerte gjenger

--- a/config/locales/models/job/en.yml
+++ b/config/locales/models/job/en.yml
@@ -16,3 +16,6 @@ en:
         tag_titles: "Tags"
         default_motivation_text_no: "Default motivation text (Norsk)"
         default_motivation_text_en: "Default motivation text (Engelsk)"
+        custom_group: "Custom group name"
+        custom_group_type: "Custom group category"
+        only_customized_admission: "Only"

--- a/config/locales/models/job/no.yml
+++ b/config/locales/models/job/no.yml
@@ -1,4 +1,4 @@
-'no':
+"no":
   helpers:
     models:
       job:
@@ -16,3 +16,6 @@
         tag_titles: "Tagger"
         default_motivation_text_no: "Standard motivasjonstekst (Norsk)"
         default_motivation_text_en: "Standard motivasjonstekst (Engelsk)"
+        custom_group: "Egendefinert gjengnavn"
+        custom_group_type: "Egendefinert gjengkategori"
+        only_customized_admission: "Only"

--- a/config/locales/views/admissions/en.yml
+++ b/config/locales/views/admissions/en.yml
@@ -28,21 +28,22 @@ en:
     statistics: "Statistics"
     groups_with_admission: "Groups with admission"
     groups_with_separate_admission: "Groups with separate admission"
+    other_groups_with_admissions: Other groups with admisssions
     separate_admission_information: "Click here for groups with separate admission"
 
     admin_applet:
       title: Admissions
 
     no_admissions:
-        header: "There are currently no admissions to positions at Samfundet"
-        ordinary_information: "Samfundet ordinairly has its admissions in the beginning of each semester. Keep an eye on this page!"
-        more_information: "For more information about samfundets groups"
-        motivation_text: |
-          We have our admissions in the beginning of each semester and it would be very much appreciated if you applied as a volunteer!
-          Studentersamfundet i Trondhjem is Norways largest student society and we have more to offer than any other city.
-          No matter what you're studying or what you might be interested in, we have a group that will suit you!
+      header: "There are currently no admissions to positions at Samfundet"
+      ordinary_information: "Samfundet ordinairly has its admissions in the beginning of each semester. Keep an eye on this page!"
+      more_information: "For more information about samfundets groups"
+      motivation_text: |
+        We have our admissions in the beginning of each semester and it would be very much appreciated if you applied as a volunteer!
+        Studentersamfundet i Trondhjem is Norways largest student society and we have more to offer than any other city.
+        No matter what you're studying or what you might be interested in, we have a group that will suit you!
 
-        see_applications_text: "You can see your applications"
-        see_applications_link: "here."
-        already_applied: "If you have already applied you can log in as applicant to prioritize and track your applications."
-        click_here: "click here."
+      see_applications_text: "You can see your applications"
+      see_applications_link: "here."
+      already_applied: "If you have already applied you can log in as applicant to prioritize and track your applications."
+      click_here: "click here."

--- a/config/locales/views/admissions/no.yml
+++ b/config/locales/views/admissions/no.yml
@@ -1,4 +1,4 @@
-'no':
+"no":
   admissions:
     admission_not_yet_open: "Opptaket klargjøres og åpner: "
     admission_promo: |
@@ -28,21 +28,22 @@
     statistics: "Statistikk"
     groups_with_admission: "Gjenger med opptak"
     groups_with_separate_admission: "Gjenger med separat opptak"
+    other_groups_with_admissions: Andre gjenger med opptak
     separate_admission_information: "Klikk her for gjenger med separat opptak"
 
     admin_applet:
       title: Opptak
 
     no_admissions:
-        header: "Det er for tiden ingen opptak på Samfundet"
-        ordinary_information: "Samfundet har sine ordinære opptak på starten av hvert semester. Følg med på denne siden!"
-        more_information: "For mer informasjon om samfundets gjenger"
-        motivation_text: |
-          Vi har opptak på starten av hvert semester og ønsker at du søker til oss som frivillig!
-          Studentersamfundet i Trondhjem er Norges største studentersamfund og vi har et tilbud andre byer bare kan drømme om.
-          Nesten uansett hvilken studiebakgrunn eller interesser du har, så finnes det en frivillig gjeng som søker nettopp deg!
+      header: "Det er for tiden ingen opptak på Samfundet"
+      ordinary_information: "Samfundet har sine ordinære opptak på starten av hvert semester. Følg med på denne siden!"
+      more_information: "For mer informasjon om samfundets gjenger"
+      motivation_text: |
+        Vi har opptak på starten av hvert semester og ønsker at du søker til oss som frivillig!
+        Studentersamfundet i Trondhjem er Norges største studentersamfund og vi har et tilbud andre byer bare kan drømme om.
+        Nesten uansett hvilken studiebakgrunn eller interesser du har, så finnes det en frivillig gjeng som søker nettopp deg!
 
-        see_applications_text: "Du kan se dine søknader"
-        see_applications_link: "her."
-        already_applied: "Hvis du allerede har søkt kan du logge inn som søker for å prioritere og følge med på dine søknader."
-        click_here: "klikk her."
+      see_applications_text: "Du kan se dine søknader"
+      see_applications_link: "her."
+      already_applied: "Hvis du allerede har søkt kan du logge inn som søker for å prioritere og følge med på dine søknader."
+      click_here: "klikk her."

--- a/config/locales/views/jobs/en.yml
+++ b/config/locales/views/jobs/en.yml
@@ -31,3 +31,4 @@ en:
     similar_jobs_not_applied_to: "Similar jobs you havent applied to"
     gdpr: "All personal information to applicants gets anonymized 3 weeks after the admission deadline"
     create_tags_example: "Example: foto, react, coffee, writer"
+    only_customized_admission: "For admissions with custom groups"

--- a/config/locales/views/jobs/no.yml
+++ b/config/locales/views/jobs/no.yml
@@ -1,4 +1,4 @@
-'no':
+"no":
   jobs:
     job_deleted: "Vervet er slettet."
     job_updated: "Vervet er oppdatert."
@@ -31,4 +31,4 @@
     similar_jobs_not_applied_to: "Lignende stillinger du ikke har søkt på"
     gdpr: "All personinformasjon til søkere blir anonymisert 3 uker etter opptaksfristen."
     create_tags_example: "Eksempel: foto, react, kaffe, skribent"
-    
+    only_customized_admission: "For opptak med egendefinerte gjenger og kategorier"

--- a/db/migrate/20240219184324_add_custom_group_and_custom_group_type_to_jobs.rb
+++ b/db/migrate/20240219184324_add_custom_group_and_custom_group_type_to_jobs.rb
@@ -1,0 +1,6 @@
+class AddCustomGroupAndCustomGroupTypeToJobs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :jobs, :custom_group, :string, default: ""
+    add_column :jobs, :custom_group_type, :string, default: ""
+  end
+end

--- a/db/migrate/20240219184330_add_customized_group_to_admission.rb
+++ b/db/migrate/20240219184330_add_customized_group_to_admission.rb
@@ -1,0 +1,5 @@
+class AddCustomizedGroupToAdmission < ActiveRecord::Migration[5.2]
+  def change
+    add_column :admissions, :customized_groups, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_06_185604) do
+ActiveRecord::Schema.define(version: 2024_02_19_184330) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 2023_08_06_185604) do
     t.datetime "actual_application_deadline"
     t.string "promo_video", default: "https://www.youtube.com/embed/T8MjwROd0dc"
     t.text "groups_with_separate_admission"
+    t.boolean "customized_groups", default: false
   end
 
   create_table "applicants", force: :cascade do |t|
@@ -353,6 +354,8 @@ ActiveRecord::Schema.define(version: 2023_08_06_185604) do
     t.datetime "updated_at", null: false
     t.text "default_motivation_text_no"
     t.text "default_motivation_text_en"
+    t.string "custom_group", default: ""
+    t.string "custom_group_type", default: ""
     t.index ["admission_id"], name: "index_jobs_on_admission_id"
   end
 


### PR DESCRIPTION
Makes it possible to create admissions with customizable groupings instead of the default Samfundet groups. This lets groups who use our recruitment system chose their own kind of grouping, which is not dependent on the Samfundet-structure.

When the customized_groups flag is set for an admission it will sort the jobs by their custom group types and custom groups instead of their samfundet-group. The link will still go to the Samfundet-group page.  If the flag is set to false, the admission will behave as before.