### PR TITLE
Increase medium image height

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -7,7 +7,7 @@ class Image < ApplicationRecord
   # attr_accessible :title, :image_file, :uploader_id, :tagstring, :uploader
 
   has_attached_file :image_file,
-                    styles: { medium: 'x180>', large: 'x400>' },
+                    styles: { medium: 'x240>', large: 'x400>' },
                     convert_options: { medium: '-quality 80', large: '-quality 80' },
                     processors: Rails.env.development? ? %i[thumbnail] : %i[thumbnail compression],
                     url: '/upload/:class/:attachment/:id_partition/:style/:filename',

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -7,7 +7,7 @@ class Image < ApplicationRecord
   # attr_accessible :title, :image_file, :uploader_id, :tagstring, :uploader
 
   has_attached_file :image_file,
-                    styles: { medium: 'x240>', large: 'x400>' },
+                    styles: { medium: 'x260>', large: 'x400>' },
                     convert_options: { medium: '-quality 80', large: '-quality 80' },
                     processors: Rails.env.development? ? %i[thumbnail] : %i[thumbnail compression],
                     url: '/upload/:class/:attachment/:id_partition/:style/:filename',


### PR DESCRIPTION
At layout's request. They've noticed some of their artwork looks quite bad on the frontpage (which uses the medium size), especially artwork using text or thin lines. This increases the height, which helps a bit. See example before/after image below:

**Before**

![medium_before](https://github.com/Samfundet/Samfundet/assets/16273164/413b30bf-68b1-43c4-a5e1-1fcfe4d30ca1)

**After**
![medium_after](https://github.com/Samfundet/Samfundet/assets/16273164/2333c862-8eb4-486e-8936-2bc9b2cddc6d)