### PR TITLE
Fix admission applet hiding logic

### DIFF
--- a/app/controllers/admissions_admin/admissions_controller.rb
+++ b/app/controllers/admissions_admin/admissions_controller.rb
@@ -218,7 +218,6 @@ class AdmissionsAdmin::AdmissionsController < AdmissionsAdmin::BaseController
 
     # TODO: Remove hack:
     # Used for hiding isfit admissions for non-isfiters, and hiding non-isfit admissions for isfiters
-    @is_nonisfit_admin = current_user.roles.where('title ILIKE ? AND title != ?', '%_opptaksansvarlig', 'isfit_opptaksansvarlig').present?
     @is_isfit_admin = current_user.roles.find_by(title: 'isfit_opptaksansvarlig').present?
     @is_limweb = current_user.roles.find_by(title: 'lim_web').present?
   end

--- a/app/views/admissions_admin/admissions/_admin_applet.html.haml
+++ b/app/views/admissions_admin/admissions/_admin_applet.html.haml
@@ -8,7 +8,7 @@
         = t('admissions.create_admission')
 
   - @admissions.each do |admission|
-    - if @is_limweb or (admission.isfit? and @is_isfit_admin) or (not admission.isfit? and (@is_nonisfit_admin or can? :manage, Admission))
+    - if @is_limweb or (admission.isfit? and @is_isfit_admin) or (not admission.isfit? and not @is_isfit_admin)
       = link_to admissions_admin_admission_path(admission) do
         .samf-button.plain.w100.mb-2
           %b= admission.title


### PR DESCRIPTION
Currently normal samf gjengsjefer who don't have the `_opptaksansvarlig` role, will not see the primary admission.

This simplifies the hiding logic.

- `lim_web` sees all
- If user has `isfit_opptaksansvarlig` role, you can only see ISFiT admissions
- Non-ISFiT admissions are hidden if user has `isfit_opptaksansvarlig` role