### PR TITLE
remove white text and fix opening button boarder

### DIFF
--- a/app/assets/stylesheets/site/_hero_unit.scss
+++ b/app/assets/stylesheets/site/_hero_unit.scss
@@ -160,7 +160,6 @@
     .area {
       text-transform: uppercase;
       font-weight: $font-weight-medium;
-      color: white;
       a {
         color: $samfundet-red;
         text-decoration: underline;

--- a/app/views/layouts/_opening_hours.html.haml
+++ b/app/views/layouts/_opening_hours.html.haml
@@ -21,8 +21,8 @@
                 = format '%s–%s',
                     I18n.l(hours.open_time, format: :time),
                     I18n.l(hours.close_time, format: :time)
-      = link_to @opening_hours_url do
-        .samf-button.center.mb-3
+      .samf-button.center.mb-3
+        = link_to @opening_hours_url do
           =  t('site.index.all-opening-hours')
       .pt-3
 


### PR DESCRIPTION
An area without an information-page would display area name with white text and therefore not be visible. 
![image](https://github.com/user-attachments/assets/556cdb2a-5520-4484-94af-3bfbaec71e9a) This is before, right being white the highlighted text.

To solve I removed the white styling, I couldnt see any other places where this was used so shouldnt affect anthing else. 
I also switch the order of styling on the button to fix the large *hitbox*

Thanks to Ivar from Snaustrinda for pointing it out to me.
 