### PR TITLE
Create and display "Open today" banner

### DIFF
--- a/app/assets/javascripts/site/open-banner.js
+++ b/app/assets/javascripts/site/open-banner.js
@@ -1,0 +1,10 @@
+(function () {
+  function onScroll() {
+    if (window.scrollY > 0) {
+      document.getElementById("header").classList.add("scrolled")
+    } else {
+      document.getElementById("header").classList.remove("scrolled")
+    }
+  }
+  document.addEventListener('scroll', onScroll);
+})();

--- a/app/assets/stylesheets/site/_open_banner.scss
+++ b/app/assets/stylesheets/site/_open_banner.scss
@@ -1,0 +1,16 @@
+.open_banner_container {
+  background: #111111;
+  padding: 2px 0;
+  border-bottom: 1px solid #323232;
+}
+
+.open_banner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 0.5rem;
+  color: white;
+}
+
+.open_time {
+  font-weight: 300;
+}

--- a/app/assets/stylesheets/site/_open_banner.scss
+++ b/app/assets/stylesheets/site/_open_banner.scss
@@ -1,6 +1,6 @@
 .open_banner_container {
   background: #111111;
-  padding: 2px 0;
+  padding-bottom: 2px;
   border-bottom: 1px solid #323232;
 }
 
@@ -9,6 +9,14 @@
   margin: 0 auto;
   padding: 0 0.5rem;
   color: white;
+
+  @media only screen and (max-width: 768px) {
+    text-align: center;
+  }
+
+  @media only screen and (max-width: 950px) {
+    padding: 0 20px;
+  }
 }
 
 .open_time {

--- a/app/assets/stylesheets/site/site.scss
+++ b/app/assets/stylesheets/site/site.scss
@@ -4,3 +4,4 @@
 @import "_mailing_list";
 @import "_banner";
 @import "nybygg_countdown";
+@import "open_banner";

--- a/app/assets/stylesheets/sitewide/_header.scss
+++ b/app/assets/stylesheets/sitewide/_header.scss
@@ -16,7 +16,11 @@
   border-bottom: 1px solid rgb(50, 50, 50);
   color: white;
 
+  transition: border-bottom-color 0.1s ease-in;
 
+  &.scroll-border:not(.scrolled) {
+    border-bottom-color: transparent;
+  }
 }
 
 #header-items, #header-items-mobile, #header-popup-menu {

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -10,6 +10,8 @@ class SiteController < ApplicationController
     @banner_event = @upcoming_events.shift
 
     @open_now = Area.joins(:standard_hours).any? { |a| a.open_now? }
+    @earliest_open_time = Area.joins(:standard_hours).map(&:earliest_open_time).compact.min
+    @latest_close_time = Area.joins(:standard_hours).map(&:latest_close_time).compact.max
 
     # Nybygg countdown
     @nybygg_countdown_enabled = Rails.application.config.nybygg_countdown_enabled

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -9,7 +9,7 @@ class SiteController < ApplicationController
     @upcoming_events = Event.front_page_events(11)
     @banner_event = @upcoming_events.shift
 
-    @open_now = Area.joins(:standard_hours).any? { |a| a.open_now? }
+    @open_today = Area.joins(:standard_hours).any? { |a| a.open_today? }
     @earliest_open_time = Area.joins(:standard_hours).map(&:earliest_open_time).compact.min
     @latest_close_time = Area.joins(:standard_hours).map(&:latest_close_time).compact.max
 

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -9,10 +9,12 @@ class SiteController < ApplicationController
     @upcoming_events = Event.front_page_events(11)
     @banner_event = @upcoming_events.shift
 
-    @open_now = Area.joins(:standard_hours).any? { |a| a.open_now? }
-    @open_today = Area.joins(:standard_hours).any? { |a| a.open_today? }
-    @earliest_open_time = Area.joins(:standard_hours).map(&:earliest_open_time).compact.min
-    @latest_close_time = Area.joins(:standard_hours).map(&:latest_close_time).compact.max
+    unless EverythingClosedPeriod.current_period
+      @open_now = Area.joins(:standard_hours).any? { |a| a.open_now? }
+      @open_today = Area.joins(:standard_hours).any? { |a| a.open_today? }
+      @earliest_open_time = Area.joins(:standard_hours).map(&:earliest_open_time).compact.min
+      @latest_close_time = Area.joins(:standard_hours).map(&:latest_close_time).compact.max
+    end
 
     # Nybygg countdown
     @nybygg_countdown_enabled = Rails.application.config.nybygg_countdown_enabled

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -9,6 +9,8 @@ class SiteController < ApplicationController
     @upcoming_events = Event.front_page_events(11)
     @banner_event = @upcoming_events.shift
 
+    @open_now = Area.joins(:standard_hours).any? { |a| a.open_now? }
+
     # Nybygg countdown
     @nybygg_countdown_enabled = Rails.application.config.nybygg_countdown_enabled
 

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -9,6 +9,7 @@ class SiteController < ApplicationController
     @upcoming_events = Event.front_page_events(11)
     @banner_event = @upcoming_events.shift
 
+    @open_now = Area.joins(:standard_hours).any? { |a| a.open_now? }
     @open_today = Area.joins(:standard_hours).any? { |a| a.open_today? }
     @earliest_open_time = Area.joins(:standard_hours).map(&:earliest_open_time).compact.min
     @latest_close_time = Area.joins(:standard_hours).map(&:latest_close_time).compact.max

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -91,6 +91,14 @@ class Area < ApplicationRecord
   def open_now?
     today&.open_now?
   end
+
+  def earliest_open_time
+    standard_hours.open_today.minimum(:open_time)
+  end
+
+  def latest_close_time
+    standard_hours.open_today.map(&:adjusted_close_time).max
+  end
 end
 
 # == Schema Information

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -87,6 +87,10 @@ class Area < ApplicationRecord
 
     open_hours
   end
+
+  def open_now?
+    today&.open_now?
+  end
 end
 
 # == Schema Information

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -88,10 +88,6 @@ class Area < ApplicationRecord
     open_hours
   end
 
-  def open_now?
-    today&.open_now?
-  end
-
   def open_today?
     today&.open
   end

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -92,6 +92,10 @@ class Area < ApplicationRecord
     today&.open_now?
   end
 
+  def open_today?
+    today&.open
+  end
+
   def earliest_open_time
     standard_hours.open_today.minimum(:open_time)
   end

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -88,6 +88,10 @@ class Area < ApplicationRecord
     open_hours
   end
 
+  def open_now?
+    today&.open_now?
+  end
+
   def open_today?
     today&.open
   end

--- a/app/models/standard_hour.rb
+++ b/app/models/standard_hour.rb
@@ -19,13 +19,6 @@ class StandardHour < ApplicationRecord
     where(day: (Time.current - 4.hours).strftime('%A').downcase)
   }
 
-  def open_now?
-    now = Time.current
-    open_time_today = Time.parse(open_time.strftime('%H:%M:%S'))
-    close_time_today = Time.parse(close_time.strftime('%H:%M:%S'))
-    open && now >= open_time_today && now <= close_time_today
-  end
-
   def adjusted_close_time
     # Adjust for times that go past midnight
     if close_time < open_time

--- a/app/models/standard_hour.rb
+++ b/app/models/standard_hour.rb
@@ -19,6 +19,13 @@ class StandardHour < ApplicationRecord
     where(day: (Time.current - 4.hours).strftime('%A').downcase)
   }
 
+  def open_now?
+    now = Time.current
+    open_time_today = Time.parse(open_time.strftime('%H:%M:%S'))
+    close_time_today = Time.parse(close_time.strftime('%H:%M:%S'))
+    open && now >= open_time_today && now <= close_time_today
+  end
+
   def adjusted_close_time
     # Adjust for times that go past midnight
     if close_time < open_time

--- a/app/models/standard_hour.rb
+++ b/app/models/standard_hour.rb
@@ -18,6 +18,13 @@ class StandardHour < ApplicationRecord
   scope :today, lambda {
     where(day: (Time.current - 4.hours).strftime('%A').downcase)
   }
+
+  def open_now?
+    now = Time.current
+    open_time_today = Time.parse(open_time.strftime('%H:%M:%S'))
+    close_time_today = Time.parse(close_time.strftime('%H:%M:%S'))
+    open && now >= open_time_today && now <= close_time_today
+  end
 end
 
 # == Schema Information

--- a/app/models/standard_hour.rb
+++ b/app/models/standard_hour.rb
@@ -25,6 +25,15 @@ class StandardHour < ApplicationRecord
     close_time_today = Time.parse(close_time.strftime('%H:%M:%S'))
     open && now >= open_time_today && now <= close_time_today
   end
+
+  def adjusted_close_time
+    # Adjust for times that go past midnight
+    if close_time < open_time
+      close_time + 1.day
+    else
+      close_time
+    end
+  end
 end
 
 # == Schema Information

--- a/app/models/standard_hour.rb
+++ b/app/models/standard_hour.rb
@@ -21,9 +21,7 @@ class StandardHour < ApplicationRecord
 
   def open_now?
     now = Time.current
-    open_time_today = Time.parse(open_time.strftime('%H:%M:%S'))
-    close_time_today = Time.parse(close_time.strftime('%H:%M:%S'))
-    open && now >= open_time_today && now <= close_time_today
+    open && now >= Time.parse(open_time.strftime('%H:%M:%S')) && now <= Time.parse(close_time.strftime('%H:%M:%S'))
   end
 
   def adjusted_close_time

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -5,7 +5,7 @@
     .cobweb
     .spider
 
-#header{ class: "#{params[:controller]} #{controller.action_name}" }
+#header{ class: "#{params[:controller]} #{controller.action_name} #{@open_now or @open_today ? 'scroll-border' : ''}" }
 
   #header-items-mobile
     = link_to root_path do

--- a/app/views/layouts/_open_banner.html.haml
+++ b/app/views/layouts/_open_banner.html.haml
@@ -1,0 +1,6 @@
+- if @open_now and @earliest_open_time and @latest_close_time
+  .open_banner_container
+    .open_banner
+      = t('areas.open_today')
+      %span.open_time
+        = "#{@earliest_open_time.strftime('%H')}–#{@latest_close_time.strftime('%H')}"

--- a/app/views/layouts/_open_banner.html.haml
+++ b/app/views/layouts/_open_banner.html.haml
@@ -1,4 +1,4 @@
-- if @open_now and @earliest_open_time and @latest_close_time
+- if @open_today and @earliest_open_time and @latest_close_time
   .open_banner_container
     .open_banner
       = t('areas.open_today')

--- a/app/views/layouts/_open_banner.html.haml
+++ b/app/views/layouts/_open_banner.html.haml
@@ -1,6 +1,6 @@
-- if @open_today and @earliest_open_time and @latest_close_time
+- if (@open_today or @open_now) and @earliest_open_time and @latest_close_time
   .open_banner_container
     .open_banner
-      = t('areas.open_today')
+      = @open_now ? t('areas.open_now') : t('areas.open_today')
       %span.open_time
         = "#{@earliest_open_time.strftime('%H')}–#{@latest_close_time.strftime('%H')}"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -26,6 +26,7 @@
     - cache [I18n.locale, 'titlebar', request.fullpath, current_user, Time.current.to_date] do
       = render 'layouts/header'
     #site-header-offset
+      = render 'layouts/open_banner'
       = yield :admissions_frontpage_highjack
       = yield :banner_image
       -# cache [I18n.locale, 'titlebar', request.fullpath, current_user, Time.current.to_date] do

--- a/config/locales/views/areas/en.yml
+++ b/config/locales/views/areas/en.yml
@@ -9,6 +9,7 @@ en:
     closing_time: "Closing time"
     open: "Open?"
     open_today: "Open today!"
+    open_now: "Open now!"
     save: "save"
     change_venue: "Change venue"
 

--- a/config/locales/views/areas/en.yml
+++ b/config/locales/views/areas/en.yml
@@ -8,6 +8,7 @@ en:
     opening_time: "Opening time"
     closing_time: "Closing time"
     open: "Open?"
+    open_today: "Open today!"
     save: "save"
     change_venue: "Change venue"
 

--- a/config/locales/views/areas/no.yml
+++ b/config/locales/views/areas/no.yml
@@ -9,6 +9,7 @@
     closing_time: "Stengetid"
     open: "Åpen?"
     open_today: "Åpent i dag!"
+    open_now: "Åpent nå!"
     save: "Lagre"
     change_venue: "Endre lokale"
 

--- a/config/locales/views/areas/no.yml
+++ b/config/locales/views/areas/no.yml
@@ -8,6 +8,7 @@
     opening_time: "Åpningstid"
     closing_time: "Stengetid"
     open: "Åpen?"
+    open_today: "Åpent i dag!"
     save: "Lagre"
     change_venue: "Endre lokale"
 


### PR DESCRIPTION
Will only show if the house is open at any point on the current day. Respects opening hours passing midnight.

Only renders on the frontpage, and is not attached to the navbar, so scrolling will hide the banner so it's not always in the way.

If currently open, will show "Åpent nå!" instead of "Åpent i dag!".

|Desktop|Mobile|
|---|---|
| <img width="557" alt="image" src="https://github.com/user-attachments/assets/2a7f6792-6f7d-4ea7-a86c-35d8071168a9" /> | <img width="426" alt="image" src="https://github.com/user-attachments/assets/2a2b78bd-dba3-4353-a125-a36c60c6a863" /> |



