### PR TITLE
Add external organizer link to events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -298,6 +298,7 @@ private
       :codeword,
       :registration_link,
       :capacity,
+      :external_organizer_link,
       price_groups_attributes: %i(name price id _destroy)
     )
   end

--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -4,7 +4,7 @@ module EventHelper
   def organizer_link(event)
     if event.organizer.is_a? Group
       group_link(event.organizer)
-    elsif event.external_organizer? and event.external_organizer_link
+    elsif event.external_organizer? and event.external_organizer_link and !event.external_organizer_link.empty?
       render 'events/external_organizer_link', event: event
     else
       event.organizer.name

--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -4,6 +4,8 @@ module EventHelper
   def organizer_link(event)
     if event.organizer.is_a? Group
       group_link(event.organizer)
+    elsif event.external_organizer? and !event.external_organizer_link.empty?
+      render 'events/external_organizer_link', event: event
     else
       event.organizer.name
     end

--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -4,7 +4,7 @@ module EventHelper
   def organizer_link(event)
     if event.organizer.is_a? Group
       group_link(event.organizer)
-    elsif event.external_organizer? and !event.external_organizer_link.empty?
+    elsif event.external_organizer? and event.external_organizer_link
       render 'events/external_organizer_link', event: event
     else
       event.organizer.name

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -237,6 +237,10 @@ class Event < ApplicationRecord
     organizer.name if organizer.is_a? ExternalOrganizer
   end
 
+  def external_organizer?
+    organizer.is_a? ExternalOrganizer
+  end
+
   def price
     case price_type
     when 'included'
@@ -401,4 +405,5 @@ end
 #  codeword              :string           default("")
 #  feedback_survey_id    :integer
 #  has_survey            :boolean
+#  external_organizer_link          :string
 #

--- a/app/views/events/_external_organizer_link.html.haml
+++ b/app/views/events/_external_organizer_link.html.haml
@@ -1,0 +1,2 @@
+= link_to event.external_organizer_link do
+  = event.organizer_external_name

--- a/app/views/events/_form.html.haml
+++ b/app/views/events/_form.html.haml
@@ -45,6 +45,9 @@
         %datalist#external_organizers
           - ExternalOrganizer.order(:name).each do |o|
             %option{ value: o.name }
+    .flex-row
+      = f.input :external_organizer_link, label: t('events.external_organizer_link'), value: @event.external_organizer_link, as: :string, hint: t('events.forms.labels.external_organizer_link')
+
 
   .flex-row
     %div{:style=>"flex-basis:100%;"}

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -50,7 +50,7 @@
       %td.pr-2.bw-r.thin= t('events.age_limit')
       %td.p-2= t_event_age_limit(@event)
 
-- if @event.external_organizer? and @event.external_organizer_link
+- if @event.external_organizer? and @event.external_organizer_link and !event.external_organizer_link.empty?
   .samf-container.small.red.text-Align.mt-2
     .mt-3.mb-3
       = t('events.external_organizer_notice')

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -50,6 +50,13 @@
       %td.pr-2.bw-r.thin= t('events.age_limit')
       %td.p-2= t_event_age_limit(@event)
 
+- if @event.external_organizer? and !@event.external_organizer_link.empty?
+  .samf-container.small.red.text-Align.mt-2
+    .mt-3.mb-3
+      = t('events.external_organizer_notice')
+      %a{href: @event.external_organizer_link, style: 'color: white; text-decoration: underline'}
+        = @event.organizer_external_name
+
 .text-Align.mb-3.pt-3.pb-3
   = render "buy_button", event: @event, button_only: false
 

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -50,7 +50,7 @@
       %td.pr-2.bw-r.thin= t('events.age_limit')
       %td.p-2= t_event_age_limit(@event)
 
-- if @event.external_organizer? and !@event.external_organizer_link.empty?
+- if @event.external_organizer? and @event.external_organizer_link
   .samf-container.small.red.text-Align.mt-2
     .mt-3.mb-3
       = t('events.external_organizer_notice')

--- a/config/locales/views/events/en.yml
+++ b/config/locales/views/events/en.yml
@@ -83,6 +83,9 @@ en:
       group: Group
       external: External
 
+    external_organizer_link: Link to external organizer
+    external_organizer_notice: Organized by an external organizer, not the groups at Samfundet. Inquiries can be directed to
+
     active: Active
     archived: Archived
     canceled: Canceled
@@ -205,6 +208,7 @@ en:
         capacity: Capacity
         registration: Registration link
         registration_hint: For external registration forms, the registration link must be added here
+        external_organizer_link: If external organizer is chosen, they can be linked to here
 
       existing_image: Select existing image
       upload_image: Upload new image

--- a/config/locales/views/events/no.yml
+++ b/config/locales/views/events/no.yml
@@ -87,6 +87,9 @@
       group: Gjeng
       external: Ekstern
 
+    external_organizer_link: Link til ekstern arrangør
+    external_organizer_notice: Arrangeres i regi av ekstern arrangør, ikke gjengene på Samfundet. Henvendelser kan rettes mot
+
     active: Aktiv
     archived: Arkivert
     canceled: Avlyst
@@ -211,6 +214,7 @@
         capacity: Plasser
         registration: Påmeldingslink
         registration_hint: Ved eksternt påmeldingsskjema må påmeldingslinken legges til her
+        external_organizer_link: Om ekstern arrangør er valgt, kan de lenkes til her
 
       existing_image: Velg eksisterende bilde
       upload_image: Last opp nytt bilde

--- a/db/migrate/20250116215548_add_external_organizer_link_to_events.rb
+++ b/db/migrate/20250116215548_add_external_organizer_link_to_events.rb
@@ -1,0 +1,7 @@
+class AddExternalOrganizerLinkToEvents < ActiveRecord::Migration[6.1]
+  def change
+    change_table :events do |t|
+      t.string :external_organizer_link, null: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_10_10_195439) do
+ActiveRecord::Schema.define(version: 2025_01_16_215548) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -227,6 +227,7 @@ ActiveRecord::Schema.define(version: 2024_10_10_195439) do
     t.string "youtube_embed"
     t.string "codeword", default: ""
     t.string "registration_link"
+    t.string "external_organizer_link"
     t.index ["billig_event_id"], name: "index_events_on_billig_event_id", unique: true
   end
 


### PR DESCRIPTION
Closes #1123 

Adds new field to events model: `external_organizer_link`. Shows up in the Event form under Arrangør/Organizer. If "External" organizer is chosen, and the link is filled out, a notice will be displayed, containing the link:

<img width="1453" alt="image" src="https://github.com/user-attachments/assets/dde6853c-4a16-4503-bef4-b033dd4f0d8a" />
