### PR TITLE
Disable registering as applicant with Microsoft-owned email

### DIFF
--- a/app/assets/javascripts/applicants/admissions_ntnu_warning.js
+++ b/app/assets/javascripts/applicants/admissions_ntnu_warning.js
@@ -1,9 +1,13 @@
-$(function() {
+$(function () {
     $("#applicant_email").on("input", function (event) {
-        if($("#applicant_email")[0].value.toString().includes("@ntnu.no")) {
+        const email = $("#applicant_email")[0].value.toString().toLowerCase();
+        if (email.includes("@ntnu.no")) {
             $(".ntnu_warning").css("display", "block");
+        } else if (email.includes("@microsoft.") || email.includes("@live.") || email.includes("@outlook.") || email.includes("@hotmail.")) {
+            $(".microsoft_warning").css("display", "block");
         } else {
             $(".ntnu_warning").css("display", "none");
+            $(".microsoft_warning").css("display", "none");
         }
     });
 });

--- a/app/assets/stylesheets/applicants/_form.scss
+++ b/app/assets/stylesheets/applicants/_form.scss
@@ -13,7 +13,7 @@
     }
 }
 
-.ntnu_warning {
+.ntnu_warning, .microsoft_warning {
   color: red;
   font-weight: 600;
   display:none;

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -19,6 +19,12 @@ class ApplicantsController < ApplicationController
     @applicant = Applicant.new(applicant_params)
     @admission = Admission.appliable.find_by_id(params[:admission])
 
+    if @applicant.email.include?('@microsoft.') or @applicant.email.include?('@live.') or @applicant.email.include?('@outlook.') or @applicant.email.include?('@hotmail.')
+      flash[:error] = (t("applicants.forms.register.microsoft_warning"))
+      render :new
+      return
+    end
+
     if @applicant.save
       flash[:success] = t('applicants.registration_success')
 

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -20,7 +20,7 @@ class ApplicantsController < ApplicationController
     @admission = Admission.appliable.find_by_id(params[:admission])
 
     if @applicant.email.include?('@microsoft.') or @applicant.email.include?('@live.') or @applicant.email.include?('@outlook.') or @applicant.email.include?('@hotmail.')
-      flash[:error] = (t("applicants.forms.register.microsoft_warning"))
+      flash[:error] = t("applicants.forms.register.microsoft_warning")
       render :new
       return
     end

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -20,7 +20,7 @@ class ApplicantsController < ApplicationController
     @admission = Admission.appliable.find_by_id(params[:admission])
 
     if @applicant.email.include?('@microsoft.') or @applicant.email.include?('@live.') or @applicant.email.include?('@outlook.') or @applicant.email.include?('@hotmail.')
-      flash[:error] = t("applicants.forms.register.microsoft_warning")
+      flash[:error] = t('applicants.forms.register.microsoft_warning')
       render :new
       return
     end

--- a/app/views/applicants/_form.html.haml
+++ b/app/views/applicants/_form.html.haml
@@ -16,6 +16,7 @@
       != form.input :email, input_html: { type: "email", value: @applicant_login_email }
       != form.input :email_confirmation, input_html: { type: "email", value: "" }
       %p.ntnu_warning= t("applicants.forms.register.ntnu_warning")
+      %p.microsoft_warning= t("applicants.forms.register.microsoft_warning")
       != form.input :password, input_html: { value: "" }
       != form.input :password_confirmation, input_html: { value: "" }
 

--- a/config/locales/views/applicants/en.yml
+++ b/config/locales/views/applicants/en.yml
@@ -32,7 +32,7 @@ en:
         heading: "Register me as applicant"
         submit: "Register me"
         ntnu_warning: "Your email contains @ntnu.no, are you sure you didn't mean @stud.ntnu.no?"
-        microsoft_warning: "We are currently having issues delivering emails to Microsoft-owned emails. Please use another another email provider, such as Gmail. If you need support, contact mg-web@samfundet.no"
+        microsoft_warning: "We are currently having issues delivering emails to Microsoft-owned emails. Please use another another email provider, such as Gmail or your student mail. If you need support, contact mg-web@samfundet.no"
         personal_information: "Personal information"
         login_information: "Log in information"
         password_information: "Password information"

--- a/config/locales/views/applicants/en.yml
+++ b/config/locales/views/applicants/en.yml
@@ -32,7 +32,7 @@ en:
         heading: "Register me as applicant"
         submit: "Register me"
         ntnu_warning: "Your email contains @ntnu.no, are you sure you didn't mean @stud.ntnu.no?"
-        microsoft_warning: "We are currently having issues delivering emails to Microsoft-owned emails. Please use another another email provider, such as Gmail or your student mail. If you need support, contact mg-web@samfundet.no"
+        microsoft_warning: "We are currently having issues delivering emails to Microsoft-owned emails. Please use another another email provider, such as Gmail. If you need support, contact mg-web@samfundet.no"
         personal_information: "Personal information"
         login_information: "Log in information"
         password_information: "Password information"

--- a/config/locales/views/applicants/en.yml
+++ b/config/locales/views/applicants/en.yml
@@ -32,6 +32,7 @@ en:
         heading: "Register me as applicant"
         submit: "Register me"
         ntnu_warning: "Your email contains @ntnu.no, are you sure you didn't mean @stud.ntnu.no?"
+        microsoft_warning: "We are currently having issues delivering emails to Microsoft-owned emails. Please use another another email provider, such as Gmail. If you need support, contact mg-web@samfundet.no"
         personal_information: "Personal information"
         login_information: "Log in information"
         password_information: "Password information"

--- a/config/locales/views/applicants/no.yml
+++ b/config/locales/views/applicants/no.yml
@@ -32,7 +32,7 @@
         heading: "Registrer meg som søker"
         submit: "Registrer meg"
         ntnu_warning: "E-posten din inneholder @ntnu.no, er du sikker på at du ikke mente @stud.ntnu.no?"
-        microsoft_warning: "Vi har for øyeblikket problemer med å levere epost til Microsoft-eide e-postadresser. Vennligst bruk en annen e-postleverandør, for eksempel Gmail eller din studentmail. Om du trenger støtte, ta kontakt med mg-web@samfundet.no"
+        microsoft_warning: "Vi har for øyeblikket problemer med å levere epost til Microsoft-eide e-postadresser. Vennligst bruk en annen e-postleverandør, for eksempel Gmail. Om du trenger støtte, ta kontakt med mg-web@samfundet.no"
         personal_information: "Personalia"
         login_information: "Påloggingsinformasjon"
         password_information: "Passordinformasjon"

--- a/config/locales/views/applicants/no.yml
+++ b/config/locales/views/applicants/no.yml
@@ -32,7 +32,7 @@
         heading: "Registrer meg som søker"
         submit: "Registrer meg"
         ntnu_warning: "E-posten din inneholder @ntnu.no, er du sikker på at du ikke mente @stud.ntnu.no?"
-        microsoft_warning: "Vi har for øyeblikket problemer med å levere epost til Microsoft-eide e-postadresser. Vennligst bruk en annen e-postleverandør, for eksempel Gmail. Om du trenger støtte, ta kontakt med mg-web@samfundet.no"
+        microsoft_warning: "Vi har for øyeblikket problemer med å levere epost til Microsoft-eide e-postadresser. Vennligst bruk en annen e-postleverandør, for eksempel Gmail eller din studentmail. Om du trenger støtte, ta kontakt med mg-web@samfundet.no"
         personal_information: "Personalia"
         login_information: "Påloggingsinformasjon"
         password_information: "Passordinformasjon"

--- a/config/locales/views/applicants/no.yml
+++ b/config/locales/views/applicants/no.yml
@@ -32,6 +32,7 @@
         heading: "Registrer meg som søker"
         submit: "Registrer meg"
         ntnu_warning: "E-posten din inneholder @ntnu.no, er du sikker på at du ikke mente @stud.ntnu.no?"
+        microsoft_warning: "Vi har for øyeblikket problemer med å levere epost til Microsoft-eide e-postadresser. Vennligst bruk en annen e-postleverandør, for eksempel Gmail. Om du trenger støtte, ta kontakt med mg-web@samfundet.no"
         personal_information: "Personalia"
         login_information: "Påloggingsinformasjon"
         password_information: "Passordinformasjon"


### PR DESCRIPTION
There's currently email delivery issues from samfundet mail servers to Microsoft. This is a workaround to ensure applicants can actually receive email from us.