### PR TITLE
Add application info link to applications overview page

### DIFF
--- a/app/views/job_applications/index.html.haml
+++ b/app/views/job_applications/index.html.haml
@@ -14,7 +14,10 @@
 %h3
   = t("jobs.gdpr")
 
-%br
+- if page_by_name_en('application-info') != "#"
+  %p
+    = link_to t('job_applications.application_info_link'), page_by_name_en('application-info')
+
 - if @admissions.empty?
   %p
     = t('jobs.no_applications')

--- a/config/locales/views/job_applications/en.yml
+++ b/config/locales/views/job_applications/en.yml
@@ -1,5 +1,6 @@
 en:
   job_applications:
+    application_info_link: "Read about when and how you will receive a response to your application"
     mine: "My applications"
     hide_withdrawn_applications: "Hide withdrawn applications"
     applications_for_group: "Applications for %{group_name}"

--- a/config/locales/views/job_applications/no.yml
+++ b/config/locales/views/job_applications/no.yml
@@ -1,5 +1,6 @@
 'no':
   job_applications:
+    application_info_link: "Les om når og hvordan du får svar på søknaden din"
     mine: "Mine søknader"
     hide_withdrawn_applications: "Skjul trekte søknader"
     applications_for_group: "Søknader på stillinger i %{group_name}"


### PR DESCRIPTION
Må opprette informasjonssiden med engelsk navn "application-info" og gjerne norske "soknadsinfo"

Fikk svar fra påtroppende redaktør at linkteksten fungerte bra.

<img width="1806" height="890" alt="image" src="https://github.com/user-attachments/assets/0500dc75-5d60-47d3-9bb8-9dfc66562053" />